### PR TITLE
Archive Conversations with Two Consecutive Failed Broadcast SMS Deliveries, refactor campaign recipient count

### DIFF
--- a/supabase/functions/_shared/constants.ts
+++ b/supabase/functions/_shared/constants.ts
@@ -2,13 +2,7 @@ const MISSIVE_API_RATE_LIMIT = 1000
 const FIRST_MESSAGES_QUEUE = 'broadcast_first_messages'
 const SECOND_MESSAGES_QUEUE_NAME = 'broadcast_second_messages'
 
-const CAMPAIGN_MESSAGES_QUEUE_NAME = 'campaign_messages'
-const CAMPAIGN_SECOND_MESSAGES_QUEUE_NAME = 'campaign_second_messages'
+const ARCHIVE_MESSAGE =
+  "This chat's been archived because the last two messages didn't go through."
 
-export {
-  CAMPAIGN_MESSAGES_QUEUE_NAME,
-  CAMPAIGN_SECOND_MESSAGES_QUEUE_NAME,
-  FIRST_MESSAGES_QUEUE,
-  MISSIVE_API_RATE_LIMIT,
-  SECOND_MESSAGES_QUEUE_NAME,
-}
+export { FIRST_MESSAGES_QUEUE, MISSIVE_API_RATE_LIMIT, SECOND_MESSAGES_QUEUE_NAME, ARCHIVE_MESSAGE }

--- a/supabase/functions/_shared/drizzle/schema.ts
+++ b/supabase/functions/_shared/drizzle/schema.ts
@@ -130,7 +130,6 @@ export const conversationsLabels = pgTable('conversations_labels', {
   id: serial('id').primaryKey().notNull(),
   createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
   conversationId: uuid('conversation_id').notNull().references(() => conversations.id, { onDelete: 'cascade' }),
-  authorPhoneNumber: text('author_phone_number').references(() => authors.phoneNumber, { onDelete: 'set null' }),
   labelId: uuid('label_id').notNull().references(() => labels.id, { onDelete: 'cascade' }),
   updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' }),
   isArchived: boolean('is_archived').default(false).notNull(),
@@ -208,10 +207,6 @@ export const invokeHistory = pgTable('invoke_history', {
   createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
   conversationId: uuid('conversation_id'),
   requestBody: jsonb('request_body'),
-}, (table) => {
-  return {
-    requestBodyIdx: index('invoke_history_request_body_idx').on(table.requestBody),
-  }
 })
 
 export const conversationsUsers = pgTable('conversations_users', {

--- a/supabase/functions/_shared/scheduledcron/cron.ts
+++ b/supabase/functions/_shared/scheduledcron/cron.ts
@@ -29,8 +29,7 @@ const reconcileTwilioStatusCron = (broadcastId: number, delay: number) => {
   `)
 }
 
-const handleFailedDeliveriesCron = () => {
-  return sql.raw(`
+const HANDLE_FAILED_DELIVERIES_CRON = sql.raw(`
     SELECT cron.schedule(
       'handle-failed-deliveries',
       '*/6 * * * *',
@@ -44,7 +43,22 @@ const handleFailedDeliveriesCron = () => {
         ) as request_id;
       $$
     );
-  `)
-}
+ `)
 
-export { handleFailedDeliveriesCron, reconcileTwilioStatusCron }
+const ARCHIVE_BROADCAST_DOUBLE_FAILURES_CRON = sql.raw(`
+    SELECT cron.schedule(
+      'archive-broadcast-double-failures',
+      '* * * * *',
+      $$
+        SELECT net.http_post(
+          url:='${Deno.env.get('EDGE_FUNCTION_URL')!}archive-broadcast-double-failures/',
+          headers:='{
+            "Content-Type": "application/json",
+            "Authorization": "Bearer ${Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!}"
+          }'::jsonb
+        ) as request_id;
+      $$
+    );
+`)
+
+export { ARCHIVE_BROADCAST_DOUBLE_FAILURES_CRON, HANDLE_FAILED_DELIVERIES_CRON, reconcileTwilioStatusCron }

--- a/supabase/functions/_shared/scheduledcron/cron.ts
+++ b/supabase/functions/_shared/scheduledcron/cron.ts
@@ -51,7 +51,7 @@ const ARCHIVE_BROADCAST_DOUBLE_FAILURES_CRON = sql.raw(`
       '* * * * *',
       $$
         SELECT net.http_post(
-          url:='${Deno.env.get('EDGE_FUNCTION_URL')!}archive-broadcast-double-failures/',
+          url:='${Deno.env.get('EDGE_FUNCTION_URL')!}archive-double-failures/',
           headers:='{
             "Content-Type": "application/json",
             "Authorization": "Bearer ${Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!}"

--- a/supabase/functions/_shared/services/BroadcastService.ts
+++ b/supabase/functions/_shared/services/BroadcastService.ts
@@ -11,10 +11,15 @@ import {
   lookupTemplate,
   messageStatuses,
 } from '../drizzle/schema.ts'
-import { handleFailedDeliveriesCron, reconcileTwilioStatusCron } from '../scheduledcron/cron.ts'
+import {
+  ARCHIVE_BROADCAST_DOUBLE_FAILURES_CRON,
+  HANDLE_FAILED_DELIVERIES_CRON,
+  reconcileTwilioStatusCron,
+} from '../scheduledcron/cron.ts'
 import MissiveUtils from '../lib/Missive.ts'
 import Twilio from '../lib/Twilio.ts'
 import {
+  BROADCAST_DOUBLE_FAILURE_QUERY,
   FAILED_DELIVERED_QUERY,
   pgmqDelete,
   pgmqRead,
@@ -26,7 +31,12 @@ import NotFoundError from '../exception/NotFoundError.ts'
 import BadRequestError from '../exception/BadRequestError.ts'
 import Sentry from '../lib/Sentry.ts'
 import { createNextBroadcast, isBroadcastRunning } from './BroadcastServiceUtils.ts'
-import { FIRST_MESSAGES_QUEUE, MISSIVE_API_RATE_LIMIT, SECOND_MESSAGES_QUEUE_NAME } from '../constants.ts'
+import {
+  ARCHIVE_MESSAGE,
+  FIRST_MESSAGES_QUEUE,
+  MISSIVE_API_RATE_LIMIT,
+  SECOND_MESSAGES_QUEUE_NAME,
+} from '../constants.ts'
 import { cloneBroadcast } from '../misc/utils.ts'
 
 const makeBroadcast = async (): Promise<void> => {
@@ -209,7 +219,7 @@ const reconcileTwilioStatus = async (
       await Promise.all([
         await supabase.execute(UNSCHEDULE_COMMANDS.DELAY_RECONCILE_TWILIO),
         await supabase.execute(UNSCHEDULE_COMMANDS.RECONCILE_TWILIO),
-        await supabase.execute(handleFailedDeliveriesCron()),
+        await supabase.execute(HANDLE_FAILED_DELIVERIES_CRON),
       ])
     } else {
       const pageToken = nextPageUrl ? new URL(nextPageUrl).searchParams.get('PageToken') : null
@@ -232,6 +242,7 @@ const handleFailedDeliveries = async () => {
   const failedDelivers = await supabase.execute(sql.raw(FAILED_DELIVERED_QUERY))
   if (!failedDelivers || failedDelivers.length === 0) {
     try {
+      await supabase.execute(ARCHIVE_BROADCAST_DOUBLE_FAILURES_CRON)
       await supabase.execute(UNSCHEDULE_COMMANDS.HANDLE_FAILED_DELIVERIES)
     } catch (e) {
       console.error(`Failed to unschedule handleFailedDeliveries: ${e}`)
@@ -319,10 +330,44 @@ const handleFailedDeliveries = async () => {
   }
 }
 
+const archiveBroadcastDoubleFailures = async () => {
+  const MAX_RUN_TIME = 60 * 1000
+  const startTime = Date.now()
+  const failedDelivers = await supabase.execute(BROADCAST_DOUBLE_FAILURE_QUERY)
+  if (!failedDelivers || failedDelivers.length === 0) {
+    await supabase.execute(UNSCHEDULE_COMMANDS.ARCHIVE_BROADCAST_DOUBLE_FAILURES)
+    return
+  }
+
+  for (const conversation of failedDelivers) {
+    const response = await MissiveUtils.createPost(
+      conversation.missive_conversation_id,
+      ARCHIVE_MESSAGE,
+      Deno.env.get('MISSIVE_ARCHIVE_LABEL_ID')!,
+    )
+    if (response.ok) {
+      console.info(`Successfully archived conversation for ${conversation.recipient_phone_number} due to double failure.`)
+    } else {
+      console.error(
+        `[archiveBroadcastDoubleFailures] Failed to archive conversation. conversationId: ${conversation.missive_conversation_id}`
+      )
+      Sentry.captureException(`Failed to archive conversation: ${conversation.missive_conversation_id}`)
+    }
+    const elapsedTime = Date.now() - startTime
+    if (elapsedTime > MAX_RUN_TIME) {
+      console.info(`Approaching time limit. Stopping.`)
+      break
+    }
+    // Respect rate limits for Missive API
+    await new Promise((resolve) => setTimeout(resolve, MISSIVE_API_RATE_LIMIT))
+  }
+}
+
 export default {
   makeBroadcast,
   sendBroadcastMessage,
   sendNow,
   reconcileTwilioStatus,
   handleFailedDeliveries,
+  archiveBroadcastDoubleFailures
 } as const

--- a/supabase/functions/archive-double-failures/.npmrc
+++ b/supabase/functions/archive-double-failures/.npmrc
@@ -1,0 +1,3 @@
+# Configuration for private npm package dependencies
+# For more information on using private registries with Edge Functions, see:
+# https://supabase.com/docs/guides/functions/import-maps#importing-from-private-registries

--- a/supabase/functions/archive-double-failures/deno.json
+++ b/supabase/functions/archive-double-failures/deno.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "lib": [
+      "deno.window"
+    ],
+    "strict": true
+  },
+  "imports": {
+    "drizzle-orm": "npm:drizzle-orm@0.28.5",
+    "drizzle-orm/postgres-js": "npm:drizzle-orm@0.28.5/postgres-js",
+    "drizzle-orm/pg-core": "npm:drizzle-orm@0.28.5/pg-core",
+    "date-fns": "https://esm.sh/date-fns@3.6.0",
+    "date-fns-tz": "npm:date-fns-tz",
+    "encoding/": "https://deno.land/std@0.210.0/encoding/",
+    "twilio": "npm:twilio@^5.4.3",
+    "postgres": "https://deno.land/x/postgresjs@v3.4.3/mod.js",
+    "base64": "https://denopkg.com/chiefbiiko/base64/mod.ts",
+    "sentry": "https://deno.land/x/sentry@8.53.0/index.mjs"
+  }
+}

--- a/supabase/functions/archive-double-failures/index.ts
+++ b/supabase/functions/archive-double-failures/index.ts
@@ -1,0 +1,14 @@
+import BroadcastService from '../_shared/services/BroadcastService.ts'
+import AppResponse from '../_shared/misc/AppResponse.ts'
+import Sentry from '../_shared/lib/Sentry.ts'
+
+Deno.serve(async () => {
+  try {
+    await BroadcastService.archiveBroadcastDoubleFailures()
+  } catch (error) {
+    console.error(`Error in BroadcastService.archiveBroadcastDoubleFailures: ${error.message}. Stack: ${error.stack}`)
+    // Cron job calls this function, so we don't want to throw an error
+    Sentry.captureException(error)
+  }
+  return AppResponse.ok()
+})

--- a/supabase/functions/campaigns/index.ts
+++ b/supabase/functions/campaigns/index.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 
 import AppResponse from '../_shared/misc/AppResponse.ts'
 import supabase from '../_shared/lib/supabase.ts'
-import { campaigns } from '../_shared/drizzle/schema.ts'
+import { campaigns, labels } from '../_shared/drizzle/schema.ts'
 import Sentry from '../_shared/lib/Sentry.ts'
 import { CreateCampaignSchema, formatCampaignSelect, RecipientCountSchema, UpdateCampaignSchema } from './dto.ts'
 import { and, asc, desc, eq, gt, sql } from 'drizzle-orm'

--- a/supabase/functions/campaigns/index.ts
+++ b/supabase/functions/campaigns/index.ts
@@ -15,31 +15,8 @@ const FUNCTION_PATH = '/campaigns/'
 app.get(`${FUNCTION_PATH}segments/`, async () => {
   try {
     const segments = await supabase
-      .select({
-        id: labels.id,
-        name: labels.name,
-        recipient_count: sql<number>`count(DISTINCT CASE WHEN ${conversationsAuthors.authorPhoneNumber} IN (
-          SELECT ${authors.phoneNumber}
-          FROM ${authors}
-          WHERE ${authors.unsubscribed} = false
-          AND ${authors.exclude} = false
-        ) THEN ${conversationsAuthors.authorPhoneNumber} ELSE NULL END)`,
-      })
+      .select({ id: labels.id, name: labels.name })
       .from(labels)
-      .leftJoin(
-        conversationsLabels,
-        and(
-          eq(labels.id, conversationsLabels.labelId),
-          eq(conversationsLabels.isArchived, false),
-        ),
-      )
-      .leftJoin(
-        conversationsAuthors,
-        eq(conversationsLabels.conversationId, conversationsAuthors.conversationId),
-      )
-      .groupBy(labels.id, labels.name, labels.createdAt)
-      .orderBy(labels.name)
-
     return AppResponse.ok(segments)
   } catch (error) {
     console.error('Error fetching segments:', error)

--- a/supabase/functions/campaigns/index.ts
+++ b/supabase/functions/campaigns/index.ts
@@ -6,7 +6,7 @@ import supabase from '../_shared/lib/supabase.ts'
 import { authors, campaigns, conversationsAuthors, conversationsLabels, labels } from '../_shared/drizzle/schema.ts'
 import Sentry from '../_shared/lib/Sentry.ts'
 import { CreateCampaignSchema, formatCampaignSelect, RecipientCountSchema, UpdateCampaignSchema } from './dto.ts'
-import { and, asc, desc, eq, gt, isNotNull, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, gt, sql } from 'drizzle-orm'
 import { validateSegments } from './helpers.ts'
 
 const app = new Hono()
@@ -30,12 +30,12 @@ app.get(`${FUNCTION_PATH}segments/`, async () => {
         conversationsLabels,
         and(
           eq(labels.id, conversationsLabels.labelId),
-          eq(conversationsLabels.isArchived, false)
-        )
+          eq(conversationsLabels.isArchived, false),
+        ),
       )
       .leftJoin(
         conversationsAuthors,
-        eq(conversationsLabels.conversationId, conversationsAuthors.conversationId)
+        eq(conversationsLabels.conversationId, conversationsAuthors.conversationId),
       )
       .groupBy(labels.id, labels.name, labels.createdAt)
       .orderBy(labels.name)

--- a/supabase/functions/campaigns/index.ts
+++ b/supabase/functions/campaigns/index.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 
 import AppResponse from '../_shared/misc/AppResponse.ts'
 import supabase from '../_shared/lib/supabase.ts'
-import { authors, campaigns, conversationsAuthors, conversationsLabels, labels } from '../_shared/drizzle/schema.ts'
+import { campaigns } from '../_shared/drizzle/schema.ts'
 import Sentry from '../_shared/lib/Sentry.ts'
 import { CreateCampaignSchema, formatCampaignSelect, RecipientCountSchema, UpdateCampaignSchema } from './dto.ts'
 import { and, asc, desc, eq, gt, sql } from 'drizzle-orm'

--- a/supabase/functions/tests/campaigns-tests.ts
+++ b/supabase/functions/tests/campaigns-tests.ts
@@ -666,7 +666,6 @@ describe('PATCH', { sanitizeOps: false, sanitizeResources: false }, () => {
       .where(eq(campaigns.id, campaign.id))
       .limit(1)
 
-    // The original campaign should be unchanged
     assertEquals(unchangedCampaign.firstMessage, 'Original message')
   })
 })

--- a/supabase/functions/tests/campaigns-tests.ts
+++ b/supabase/functions/tests/campaigns-tests.ts
@@ -822,7 +822,7 @@ describe('GET', { sanitizeOps: false, sanitizeResources: false }, () => {
 })
 
 describe('GET /campaigns/segments/', { sanitizeOps: false, sanitizeResources: false }, () => {
-  it('should return segments with correct recipient counts', async () => {
+  it('should return segments with id and name', async () => {
     const label1 = await createLabel({ name: 'Label A' })
     const label2 = await createLabel({ name: 'Label B' })
 
@@ -863,10 +863,12 @@ describe('GET /campaigns/segments/', { sanitizeOps: false, sanitizeResources: fa
     assertEquals(data.length, 2)
     assertEquals(data[0].id, label1.id)
     assertEquals(data[0].name, 'Label A')
-    assertEquals(data[0].recipient_count, '2')
     assertEquals(data[1].id, label2.id)
     assertEquals(data[1].name, 'Label B')
-    assertEquals(data[1].recipient_count, '1')
+
+    // Ensure only id and name are returned
+    assertEquals(Object.keys(data[0]).sort(), ['id', 'name'].sort())
+    assertEquals(Object.keys(data[1]).sort(), ['id', 'name'].sort())
   })
 
   it('should handle labels with no conversations', async () => {
@@ -879,7 +881,7 @@ describe('GET /campaigns/segments/', { sanitizeOps: false, sanitizeResources: fa
     assertEquals(data.length, 1)
     assertEquals(data[0].id, label.id)
     assertEquals(data[0].name, 'Empty Label')
-    assertEquals(data[0].recipient_count, '0')
+    assertEquals(Object.keys(data[0]).sort(), ['id', 'name'].sort())
   })
 
   it('should handle labels with only archived conversations', async () => {
@@ -907,7 +909,9 @@ describe('GET /campaigns/segments/', { sanitizeOps: false, sanitizeResources: fa
     assertEquals(data.length, 1)
     assertEquals(data[0].id, label.id)
     assertEquals(data[0].name, 'Archived Label')
-    assertEquals(data[0].recipient_count, '0')
+
+    // Ensure only id and name are returned
+    assertEquals(Object.keys(data[0]).sort(), ['id', 'name'].sort())
   })
 
   it('should handle labels with only unsubscribed or excluded authors', async () => {
@@ -945,7 +949,8 @@ describe('GET /campaigns/segments/', { sanitizeOps: false, sanitizeResources: fa
     assertEquals(data.length, 1)
     assertEquals(data[0].id, label.id)
     assertEquals(data[0].name, 'Test Label')
-    assertEquals(data[0].recipient_count, '0')
+
+    assertEquals(Object.keys(data[0]).sort(), ['id', 'name'].sort())
   })
 })
 

--- a/supabase/functions/tests/factories/conversation-author.ts
+++ b/supabase/functions/tests/factories/conversation-author.ts
@@ -1,0 +1,18 @@
+import { conversationsAuthors } from '../../_shared/drizzle/schema.ts'
+import supabase from '../../_shared/lib/supabase.ts'
+
+type CreateConversationAuthorParams = {
+  conversationId: string
+  authorPhoneNumber: string
+}
+
+export async function createConversationAuthor({ conversationId, authorPhoneNumber }: CreateConversationAuthorParams) {
+  const [conversationAuthor] = await supabase
+    .insert(conversationsAuthors)
+    .values({
+      conversationId,
+      authorPhoneNumber,
+    })
+    .returning()
+  return conversationAuthor
+}

--- a/supabase/functions/tests/factories/conversation-label.ts
+++ b/supabase/functions/tests/factories/conversation-label.ts
@@ -4,14 +4,12 @@ import { createConversation } from './conversation.ts'
 
 export type CreateConversationLabelParams = {
   labelId: string
-  authorPhoneNumber: string
   isArchived?: boolean
   conversationId?: string
 }
 
 export const createConversationLabel = async ({
   labelId,
-  authorPhoneNumber,
   isArchived = false,
   conversationId,
 }: CreateConversationLabelParams) => {
@@ -22,7 +20,6 @@ export const createConversationLabel = async ({
     .insert(conversationsLabels)
     .values({
       labelId,
-      authorPhoneNumber,
       isArchived,
       conversationId: conversationId || conversation!.id,
     })

--- a/supabase/functions/tests/setup.ts
+++ b/supabase/functions/tests/setup.ts
@@ -15,6 +15,7 @@ beforeEach(async () => {
     '../../migrations/20250228040858_add_campaign_support_to_message_statuses.sql',
     '../../migrations/20250303034658_drop_reply_to_broadcast_fkey.sql',
     '../../migrations/20250304080718_add_recipient_count_to_campaigns.sql',
+    '../../migrations/20250306085822_count_campaign_recipient_using_conversations_authors_table.sql',
   ]
 
   for (const filePath of migrationFiles) {
@@ -61,4 +62,5 @@ export const DROP_ALL_TABLES = `
   DROP TABLE IF EXISTS "broadcast_settings" CASCADE;
   DROP TABLE IF EXISTS "unsubscribed_messages" CASCADE;
   DROP TABLE IF EXISTS "campaigns" CASCADE;
+  DROP FUNCTION IF EXISTS queue_campaign_messages(INTEGER);
 `

--- a/supabase/functions/user-actions/handlers/broadcast-handlers.ts
+++ b/supabase/functions/user-actions/handlers/broadcast-handlers.ts
@@ -78,7 +78,6 @@ const handleBroadcastReply = async (requestBody: RequestBody) => {
     const deliveredDate = new Date(requestMessage.delivered_at * 1000)
 
     const sentMessage = await findRecentBroadcastOrCampaignMessage(phoneNumber, deliveredDate)
-    console.log(sentMessage, 'sentMessage', phoneNumber, deliveredDate)
     if (sentMessage.length > 0) {
       // Update Twilio message with broadcast reply info
       // TODO: rename isBroadcastReply and replyToBroadcast

--- a/supabase/functions/user-actions/handlers/label-handler.ts
+++ b/supabase/functions/user-actions/handlers/label-handler.ts
@@ -6,6 +6,6 @@ export const handleLabelChange = async (requestBody: RequestBody) => {
   await supabase.transaction(async (tx) => {
     await upsertRule(tx, requestBody.rule)
     await upsertConversation(tx, requestBody.conversation)
-    await upsertLabel(tx, requestBody.conversation)
+    await upsertLabel(tx, requestBody)
   })
 }

--- a/supabase/functions/user-actions/handlers/twilio-message-handler.ts
+++ b/supabase/functions/user-actions/handlers/twilio-message-handler.ts
@@ -15,7 +15,7 @@ const handleTwilioMessage = async (requestBody: RequestBody) => {
     await upsertRule(tx, requestBody.rule)
     await upsertConversation(tx, requestBody.conversation)
     await insertTwilioMessage(tx, requestBody)
-    await upsertLabel(tx, requestBody.conversation)
+    await upsertLabel(tx, requestBody)
   })
 }
 

--- a/supabase/functions/user-actions/handlers/twilio-message-handler.ts
+++ b/supabase/functions/user-actions/handlers/twilio-message-handler.ts
@@ -1,7 +1,7 @@
 import { PostgresJsTransaction } from 'drizzle-orm/postgres-js'
 import { eq } from 'drizzle-orm'
 
-import { ConversationAuthor, authors, conversationsAuthors, twilioMessages } from '../../_shared/drizzle/schema.ts'
+import { authors, ConversationAuthor, conversationsAuthors, twilioMessages } from '../../_shared/drizzle/schema.ts'
 import { RequestBody } from '../types.ts'
 import { upsertAuthor, upsertConversation, upsertLabel, upsertRule } from './utils.ts'
 import { adaptTwilioMessage, adaptTwilioRequestAuthor } from '../adapters.ts'

--- a/supabase/functions/user-actions/handlers/utils.ts
+++ b/supabase/functions/user-actions/handlers/utils.ts
@@ -241,22 +241,7 @@ export const upsertLabel = async (
       shareWithOrganization: label.share_with_organization,
       visibility: label.visibility,
     })
-    requestConvo.authors.forEach((author) => {
-      if (author.phone_number) {
-        requestConversationsLabels.add({
-          conversationId: requestConvo.id,
-          labelId: label.id,
-          authorPhoneNumber: author.phone_number,
-        })
-      }
-    })
-    if (requestBody.message?.to_fields?.[0]?.id || requestBody.latest_message?.to_fields?.[0]?.id) {
-      requestConversationsLabels.add({
-        conversationId: requestConvo.id,
-        labelId: label.id,
-        authorPhoneNumber: requestBody.message?.to_fields?.[0]?.id || requestBody.latest_message?.to_fields?.[0]?.id,
-      })
-    }
+    requestConversationsLabels.add({ conversationId: requestConvo.id, labelId: label.id })
     labelIds.push(label.id)
   }
   if (requestLabels.size > 0) {
@@ -284,11 +269,9 @@ export const upsertLabel = async (
         eq(conversationsLabels.conversationId, requestConvo.id!),
         notInArray(conversationsLabels.labelId, labelIds),
       ))
-    if (requestConversationsLabels.size > 0) {
-      await tx.insert(conversationsLabels).values([
-        ...requestConversationsLabels,
-      ]).onConflictDoNothing()
-    }
+    await tx.insert(conversationsLabels).values([
+      ...requestConversationsLabels,
+    ]).onConflictDoNothing()
   }
 }
 

--- a/supabase/functions/user-actions/handlers/utils.ts
+++ b/supabase/functions/user-actions/handlers/utils.ts
@@ -250,11 +250,11 @@ export const upsertLabel = async (
         })
       }
     })
-    if (requestBody.message?.to_fields?.[0]?.id) {
+    if (requestBody.message?.to_fields?.[0]?.id || requestBody.latest_message?.to_fields?.[0]?.id) {
       requestConversationsLabels.add({
         conversationId: requestConvo.id,
         labelId: label.id,
-        authorPhoneNumber: requestBody.message.to_fields[0].id,
+        authorPhoneNumber: requestBody.message?.to_fields?.[0]?.id || requestBody.latest_message?.to_fields?.[0]?.id,
       })
     }
     labelIds.push(label.id)

--- a/supabase/functions/user-actions/types.ts
+++ b/supabase/functions/user-actions/types.ts
@@ -27,6 +27,7 @@ export type RequestBody = {
   latest_message?: {
     id: string
     references: string[]
+    to_fields: TwilioRequestAuthor[]
   }
   message?: TwilioRequestMessage
 }

--- a/supabase/migrations/0000_minor_magik.sql
+++ b/supabase/migrations/0000_minor_magik.sql
@@ -420,7 +420,6 @@ CREATE INDEX IF NOT EXISTS "unsubscribed_messages_reply_to_idx" ON "unsubscribed
 CREATE INDEX IF NOT EXISTS "idx_user_history_id" ON "user_history" ("id");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "user_history_user_id_idx" ON "user_history" ("user_id");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_authors_phone_unsub_exclude" ON "authors" ("phone_number","unsubscribed","exclude");--> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "invoke_history_request_body_idx" ON "invoke_history" ("request_body");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_tm_from_created_broadcast" ON "twilio_messages" ("created_at","from_field","is_broadcast_reply");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_twilio_messages_created_from_broadcast" ON "twilio_messages" ("created_at","from_field","is_broadcast_reply");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_twilio_messages_delivered_from" ON "twilio_messages" ("delivered_at","from_field");--> statement-breakpoint

--- a/supabase/migrations/20250306085822_count_campaign_recipient_using_conversations_authors_table.sql
+++ b/supabase/migrations/20250306085822_count_campaign_recipient_using_conversations_authors_table.sql
@@ -1,0 +1,640 @@
+CREATE OR REPLACE FUNCTION get_campaign_recipient_count(
+  p_segments JSONB
+) RETURNS INTEGER AS $$
+DECLARE
+  included_phone_numbers TEXT[];
+  excluded_phone_numbers TEXT[];
+  p_included_segments JSONB;
+  p_excluded_segments JSONB;
+  phone_count INTEGER;
+BEGIN
+  -- Extract included and excluded segments from the input
+  p_included_segments := p_segments->'included';
+  p_excluded_segments := p_segments->'excluded';
+
+  -- Get phone numbers for included segments
+  WITH RECURSIVE
+    -- Process included segments based on type
+    segments_prep AS (
+      SELECT
+        CASE
+          WHEN jsonb_typeof(p_included_segments) = 'object'
+          THEN jsonb_build_array(p_included_segments)
+          ELSE p_included_segments
+        END AS segments_array
+    ),
+    -- Extract all segment IDs from included segments
+    segment_ids AS (
+      SELECT jsonb_array_elements(segments_array) AS segment
+      FROM segments_prep
+    ),
+    -- Process AND groups separately
+    segment_items AS (
+      SELECT
+        segment,
+        jsonb_typeof(segment) AS segment_type
+      FROM segment_ids
+    ),
+    -- Single segments (direct use)
+    single_segments AS (
+      SELECT segment AS item
+      FROM segment_items
+      WHERE segment_type = 'object'
+    ),
+    -- AND groups (need to be expanded)
+    and_groups AS (
+      SELECT jsonb_array_elements(segment) AS item
+      FROM segment_items
+      WHERE segment_type = 'array'
+    ),
+    -- Combine all segments
+    all_segments AS (
+      SELECT item FROM single_segments
+      UNION ALL
+      SELECT item FROM and_groups
+    ),
+    -- Get all eligible authors
+    eligible_authors AS (
+      SELECT phone_number
+      FROM authors
+      WHERE unsubscribed = FALSE AND exclude = FALSE
+    ),
+    -- Get matching phone numbers for each segment
+    matching_phones AS (
+      SELECT DISTINCT ca.author_phone_number, fs.item
+      FROM all_segments fs
+      JOIN LATERAL (
+        -- For each segment, get matching phone numbers
+        SELECT ca.author_phone_number
+        FROM conversations_labels cl
+        JOIN conversations_authors ca ON cl.conversation_id = ca.conversation_id
+        JOIN eligible_authors ea ON ca.author_phone_number = ea.phone_number
+        WHERE
+          cl.is_archived = FALSE
+          AND cl.label_id = (fs.item->>'id')::UUID
+          AND (
+            -- Apply date filter if present
+            (fs.item->>'since') IS NULL
+            OR cl.created_at >= to_timestamp((fs.item->>'since')::BIGINT)
+          )
+      ) ca ON TRUE
+    ),
+    -- Handle AND groups - group by phone and count labels
+    phone_label_counts AS (
+      SELECT
+        author_phone_number,
+        COUNT(DISTINCT (item->>'id')::UUID) AS label_count
+      FROM matching_phones
+      GROUP BY author_phone_number
+    ),
+    -- For AND groups, get phones that have all required labels
+    and_group_phones AS (
+      SELECT DISTINCT si.segment, mp.author_phone_number
+      FROM segment_items si
+      JOIN matching_phones mp ON mp.item->>'id' = ANY(
+        ARRAY(
+          SELECT jsonb_array_elements(si.segment)->>'id'
+          WHERE si.segment_type = 'array'
+        )
+      )
+      WHERE si.segment_type = 'array'
+      GROUP BY si.segment, mp.author_phone_number
+      HAVING COUNT(DISTINCT (mp.item->>'id')::UUID) = jsonb_array_length(si.segment)
+    ),
+    -- Single segment phones
+    single_segment_phones AS (
+      SELECT DISTINCT author_phone_number
+      FROM matching_phones
+      WHERE (item->>'id')::UUID IN (
+        SELECT (segment->>'id')::UUID
+        FROM segment_items
+        WHERE segment_type = 'object'
+      )
+    ),
+    -- Combine all matching phones (OR logic between groups)
+    final_included_phones AS (
+      SELECT author_phone_number FROM single_segment_phones
+      UNION
+      SELECT author_phone_number FROM and_group_phones
+    )
+    -- Get the final array of included phone numbers
+    SELECT ARRAY_AGG(DISTINCT author_phone_number) INTO included_phone_numbers
+    FROM final_included_phones;
+
+  -- If excluded segments are provided, get those phone numbers
+  IF p_excluded_segments IS NOT NULL THEN
+    WITH RECURSIVE
+      -- Process excluded segments based on type
+      segments_prep AS (
+        SELECT
+          CASE
+            WHEN jsonb_typeof(p_excluded_segments) = 'object'
+            THEN jsonb_build_array(p_excluded_segments)
+            ELSE p_excluded_segments
+          END AS segments_array
+      ),
+      -- Extract all segment IDs from excluded segments
+      segment_ids AS (
+        SELECT jsonb_array_elements(segments_array) AS segment
+        FROM segments_prep
+      ),
+      -- Process AND groups separately
+      segment_items AS (
+        SELECT
+          segment,
+          jsonb_typeof(segment) AS segment_type
+        FROM segment_ids
+      ),
+      -- Single segments (direct use)
+      single_segments AS (
+        SELECT segment AS item
+        FROM segment_items
+        WHERE segment_type = 'object'
+      ),
+      -- AND groups (need to be expanded)
+      and_groups AS (
+        SELECT jsonb_array_elements(segment) AS item
+        FROM segment_items
+        WHERE segment_type = 'array'
+      ),
+      -- Combine all segments
+      all_segments AS (
+        SELECT item FROM single_segments
+        UNION ALL
+        SELECT item FROM and_groups
+      ),
+      -- Get matching phone numbers for each segment
+      matching_phones AS (
+        SELECT DISTINCT ca.author_phone_number, fs.item
+        FROM all_segments fs
+        JOIN LATERAL (
+          -- For each segment, get matching phone numbers
+          SELECT ca.author_phone_number
+          FROM conversations_labels cl
+          JOIN conversations_authors ca ON cl.conversation_id = ca.conversation_id
+          WHERE
+            cl.is_archived = FALSE
+            AND cl.label_id = (fs.item->>'id')::UUID
+            AND (
+              -- Apply date filter if present
+              (fs.item->>'since') IS NULL
+              OR cl.created_at >= to_timestamp((fs.item->>'since')::BIGINT)
+            )
+        ) ca ON TRUE
+      ),
+      -- Handle AND groups - group by phone and count labels
+      phone_label_counts AS (
+        SELECT
+          author_phone_number,
+          COUNT(DISTINCT (item->>'id')::UUID) AS label_count
+        FROM matching_phones
+        GROUP BY author_phone_number
+      ),
+      -- For AND groups, get phones that have all required labels
+      and_group_phones AS (
+        SELECT DISTINCT si.segment, mp.author_phone_number
+        FROM segment_items si
+        JOIN matching_phones mp ON mp.item->>'id' = ANY(
+          ARRAY(
+            SELECT jsonb_array_elements(si.segment)->>'id'
+            WHERE si.segment_type = 'array'
+          )
+        )
+        WHERE si.segment_type = 'array'
+        GROUP BY si.segment, mp.author_phone_number
+        HAVING COUNT(DISTINCT (mp.item->>'id')::UUID) = jsonb_array_length(si.segment)
+      ),
+      -- Single segment phones
+      single_segment_phones AS (
+        SELECT DISTINCT author_phone_number
+        FROM matching_phones
+        WHERE (item->>'id')::UUID IN (
+          SELECT (segment->>'id')::UUID
+          FROM segment_items
+          WHERE segment_type = 'object'
+        )
+      ),
+      -- Combine all matching phones (OR logic between groups)
+      final_excluded_phones AS (
+        SELECT author_phone_number FROM single_segment_phones
+        UNION
+        SELECT author_phone_number FROM and_group_phones
+      )
+      -- Get the final array of excluded phone numbers
+      SELECT ARRAY_AGG(DISTINCT author_phone_number) INTO excluded_phone_numbers
+      FROM final_excluded_phones;
+  END IF;
+
+  -- Count the final set of phone numbers (included - excluded)
+  IF included_phone_numbers IS NULL THEN
+    RETURN 0;
+  ELSIF excluded_phone_numbers IS NULL OR array_length(excluded_phone_numbers, 1) = 0 THEN
+    RETURN array_length(included_phone_numbers, 1);
+  ELSE
+    SELECT COUNT(*) INTO phone_count
+    FROM (
+      SELECT unnest(included_phone_numbers) AS phone_number
+      EXCEPT
+      SELECT unnest(excluded_phone_numbers) AS phone_number
+    ) phones;
+
+    RETURN phone_count;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+----------------------------------------------------------
+DROP FUNCTION IF EXISTS queue_campaign_messages(INTEGER);
+CREATE OR REPLACE FUNCTION queue_campaign_messages(
+    p_campaign_id INTEGER
+) RETURNS INTEGER AS $$
+DECLARE
+    v_campaign_record campaigns%ROWTYPE;
+    v_recipient_sql TEXT;
+    v_batch_size CONSTANT INTEGER := 100;
+    v_offset INTEGER;
+    v_total_recipients INTEGER;
+BEGIN
+    SELECT * INTO v_campaign_record
+    FROM campaigns
+    WHERE id = p_campaign_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Campaign with ID % not found', p_campaign_id;
+    END IF;
+
+    CREATE TEMPORARY TABLE campaign_recipients_temp (
+        phone_number TEXT PRIMARY KEY
+    );
+
+    -- Generate SQL to get recipients
+    v_recipient_sql := '
+    WITH RECURSIVE
+      -- Extract segments from campaign
+      campaign_data AS (
+        SELECT
+          ''' || v_campaign_record.segments::TEXT || '''::jsonb->''included'' AS p_included_segments,
+          ''' || v_campaign_record.segments::TEXT || '''::jsonb->''excluded'' AS p_excluded_segments
+      ),
+      -- Process included segments based on type
+      segments_prep AS (
+        SELECT
+          CASE
+            WHEN jsonb_typeof(p_included_segments) = ''object''
+            THEN jsonb_build_array(p_included_segments)
+            ELSE p_included_segments
+          END AS segments_array
+        FROM campaign_data
+      ),
+      -- Extract all segment IDs from included segments
+      segment_ids AS (
+        SELECT jsonb_array_elements(segments_array) AS segment
+        FROM segments_prep
+      ),
+      -- Process AND groups separately
+      segment_items AS (
+        SELECT
+          segment,
+          jsonb_typeof(segment) AS segment_type
+        FROM segment_ids
+      ),
+      -- Single segments (direct use)
+      single_segments AS (
+        SELECT segment AS item
+        FROM segment_items
+        WHERE segment_type = ''object''
+      ),
+      -- AND groups (need to be expanded)
+      and_groups AS (
+        SELECT jsonb_array_elements(segment) AS item
+        FROM segment_items
+        WHERE segment_type = ''array''
+      ),
+      -- Combine all segments
+      all_segments AS (
+        SELECT item FROM single_segments
+        UNION ALL
+        SELECT item FROM and_groups
+      ),
+      -- Get all eligible authors
+      eligible_authors AS (
+        SELECT phone_number
+        FROM authors
+        WHERE unsubscribed = FALSE AND exclude = FALSE
+      ),
+      -- Get matching phone numbers for each segment
+      matching_phones AS (
+        SELECT DISTINCT ca.author_phone_number, fs.item
+        FROM all_segments fs
+        JOIN LATERAL (
+          -- For each segment, get matching phone numbers
+          SELECT ca.author_phone_number
+          FROM conversations_labels cl
+          JOIN conversations_authors ca ON cl.conversation_id = ca.conversation_id
+          JOIN eligible_authors ea ON ca.author_phone_number = ea.phone_number
+          WHERE
+            cl.is_archived = FALSE
+            AND cl.label_id = (fs.item->>''id'')::UUID
+            AND (
+              -- Apply date filter if present
+              (fs.item->>''since'') IS NULL
+              OR cl.created_at >= to_timestamp((fs.item->>''since'')::BIGINT)
+            )
+        ) ca ON TRUE
+      ),
+      -- Handle AND groups - group by phone and count labels
+      phone_label_counts AS (
+        SELECT
+          author_phone_number,
+          COUNT(DISTINCT (item->>''id'')::UUID) AS label_count
+        FROM matching_phones
+        GROUP BY author_phone_number
+      ),
+      -- For AND groups, get phones that have all required labels
+      and_group_phones AS (
+        SELECT DISTINCT si.segment, mp.author_phone_number
+        FROM segment_items si
+        JOIN matching_phones mp ON mp.item->>''id'' = ANY(
+          ARRAY(
+            SELECT jsonb_array_elements(si.segment)->>''id''
+            WHERE si.segment_type = ''array''
+          )
+        )
+        WHERE si.segment_type = ''array''
+        GROUP BY si.segment, mp.author_phone_number
+        HAVING COUNT(DISTINCT (mp.item->>''id'')::UUID) = jsonb_array_length(si.segment)
+      ),
+      -- Single segment phones
+      single_segment_phones AS (
+        SELECT DISTINCT author_phone_number
+        FROM matching_phones
+        WHERE (item->>''id'')::UUID IN (
+          SELECT (segment->>''id'')::UUID
+          FROM segment_items
+          WHERE segment_type = ''object''
+        )
+      ),
+      -- Combine all matching phones (OR logic between groups)
+      included_phones AS (
+        SELECT author_phone_number FROM single_segment_phones
+        UNION
+        SELECT author_phone_number FROM and_group_phones
+      )';
+
+    -- Add excluded segments logic if they exist
+    IF v_campaign_record.segments->>'excluded' IS NOT NULL THEN
+      v_recipient_sql := v_recipient_sql || ',
+      -- Process excluded segments based on type
+      excluded_segments_prep AS (
+        SELECT
+          CASE
+            WHEN jsonb_typeof(p_excluded_segments) = ''object''
+            THEN jsonb_build_array(p_excluded_segments)
+            ELSE p_excluded_segments
+          END AS segments_array
+        FROM campaign_data
+      ),
+      -- Extract all segment IDs from excluded segments
+      excluded_segment_ids AS (
+        SELECT jsonb_array_elements(segments_array) AS segment
+        FROM excluded_segments_prep
+      ),
+      -- Process AND groups separately
+      excluded_segment_items AS (
+        SELECT
+          segment,
+          jsonb_typeof(segment) AS segment_type
+        FROM excluded_segment_ids
+      ),
+      -- Single segments (direct use)
+      excluded_single_segments AS (
+        SELECT segment AS item
+        FROM excluded_segment_items
+        WHERE segment_type = ''object''
+      ),
+      -- AND groups (need to be expanded)
+      excluded_and_groups AS (
+        SELECT jsonb_array_elements(segment) AS item
+        FROM excluded_segment_items
+        WHERE segment_type = ''array''
+      ),
+      -- Combine all segments
+      excluded_all_segments AS (
+        SELECT item FROM excluded_single_segments
+        UNION ALL
+        SELECT item FROM excluded_and_groups
+      ),
+      -- Get matching phone numbers for each segment
+      excluded_matching_phones AS (
+        SELECT DISTINCT ca.author_phone_number, fs.item
+        FROM excluded_all_segments fs
+        JOIN LATERAL (
+          -- For each segment, get matching phone numbers
+          SELECT ca.author_phone_number
+          FROM conversations_labels cl
+          JOIN conversations_authors ca ON cl.conversation_id = ca.conversation_id
+          WHERE
+            cl.is_archived = FALSE
+            AND cl.label_id = (fs.item->>''id'')::UUID
+            AND (
+              -- Apply date filter if present
+              (fs.item->>''since'') IS NULL
+              OR cl.created_at >= to_timestamp((fs.item->>''since'')::BIGINT)
+            )
+        ) ca ON TRUE
+      ),
+      -- Handle AND groups - group by phone and count labels
+      excluded_phone_label_counts AS (
+        SELECT
+          author_phone_number,
+          COUNT(DISTINCT (item->>''id'')::UUID) AS label_count
+        FROM excluded_matching_phones
+        GROUP BY author_phone_number
+      ),
+      -- For AND groups, get phones that have all required labels
+      excluded_and_group_phones AS (
+        SELECT DISTINCT si.segment, mp.author_phone_number
+        FROM excluded_segment_items si
+        JOIN excluded_matching_phones mp ON mp.item->>''id'' = ANY(
+          ARRAY(
+            SELECT jsonb_array_elements(si.segment)->>''id''
+            WHERE si.segment_type = ''array''
+          )
+        )
+        WHERE si.segment_type = ''array''
+        GROUP BY si.segment, mp.author_phone_number
+        HAVING COUNT(DISTINCT (mp.item->>''id'')::UUID) = jsonb_array_length(si.segment)
+      ),
+      -- Single segment phones
+      excluded_single_segment_phones AS (
+        SELECT DISTINCT author_phone_number
+        FROM excluded_matching_phones
+        WHERE (item->>''id'')::UUID IN (
+          SELECT (segment->>''id'')::UUID
+          FROM excluded_segment_items
+          WHERE segment_type = ''object''
+        )
+      ),
+      -- Combine all matching phones (OR logic between groups)
+      excluded_phones AS (
+        SELECT author_phone_number FROM excluded_single_segment_phones
+        UNION
+        SELECT author_phone_number FROM excluded_and_group_phones
+      )';
+    END IF;
+
+    -- Finalize the query with the appropriate filtering and insert into temp table
+    IF v_campaign_record.segments->>'excluded' IS NOT NULL THEN
+      v_recipient_sql := 'INSERT INTO campaign_recipients_temp (phone_number)
+      ' || v_recipient_sql || '
+      -- Get the final list of phone numbers (included - excluded)
+      SELECT DISTINCT author_phone_number
+      FROM included_phones
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM excluded_phones
+        WHERE excluded_phones.author_phone_number = included_phones.author_phone_number
+      );';
+    ELSE
+      v_recipient_sql := 'INSERT INTO campaign_recipients_temp (phone_number)
+      ' || v_recipient_sql || '
+      -- Get the distinct recipient phone numbers
+      SELECT DISTINCT author_phone_number
+      FROM included_phones;';
+    END IF;
+
+    EXECUTE v_recipient_sql;
+
+    SELECT COUNT(*) INTO v_total_recipients FROM campaign_recipients_temp;
+    RAISE NOTICE 'Campaign % has % recipients', p_campaign_id, v_total_recipients;
+
+    FOR v_offset IN 0..CEIL(v_total_recipients::FLOAT / v_batch_size) - 1 LOOP
+        PERFORM pgmq.send_batch(
+            'broadcast_first_messages',
+            ARRAY(
+                SELECT jsonb_build_object(
+                    'recipient_phone_number', phone_number,
+                    'campaign_id', p_campaign_id,
+                    'first_message', v_campaign_record.first_message,
+                    'second_message', v_campaign_record.second_message,
+                    'title', v_campaign_record.title,
+                    'delay', v_campaign_record.delay,
+                    'created_at', EXTRACT(EPOCH FROM NOW())::INTEGER
+                )
+                FROM campaign_recipients_temp
+                LIMIT v_batch_size
+                OFFSET v_offset * v_batch_size
+            )
+        );
+    END LOOP;
+
+    -- Update the campaign's recipient count
+    UPDATE campaigns
+    SET recipient_count = v_total_recipients
+    WHERE id = p_campaign_id;
+
+    RAISE NOTICE 'Campaign % has been queued with % recipients', p_campaign_id, v_total_recipients;
+
+    -- Return the number of recipients
+    RETURN v_total_recipients;
+END;
+$$ LANGUAGE plpgsql;
+-------------------------------------------------------
+CREATE OR REPLACE FUNCTION check_and_run_campaigns()
+RETURNS jsonb AS $$
+DECLARE
+    campaign_record campaigns%ROWTYPE;
+    current_timestamp_utc TIMESTAMP WITH TIME ZONE;
+    campaigns_to_run INTEGER;
+    campaign_ids INTEGER[];
+    future_timestamp TIMESTAMP WITH TIME ZONE;
+    cron_expression TEXT;
+    service_key TEXT;
+    edge_url TEXT;
+    cron_command TEXT;
+    recipient_count INTEGER;
+    seconds_to_add INTEGER;
+BEGIN
+    current_timestamp_utc := CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
+    SELECT array_agg(id), COUNT(*) INTO campaign_ids, campaigns_to_run
+    FROM campaigns
+    WHERE
+        date_trunc('minute', run_at) = date_trunc('minute', current_timestamp_utc)
+        AND processed IS FALSE;
+
+    RAISE LOG '[check_and_run_campaigns] Checking for campaigns to run. Current time: %, Found: %',
+        current_timestamp_utc, campaigns_to_run;
+
+    IF campaigns_to_run = 0 OR campaign_ids IS NULL THEN
+        RAISE WARNING '[check_and_run_campaigns] No campaigns scheduled to run at this time';
+        RETURN jsonb_build_object('status', 'no_campaigns_to_run');
+    END IF;
+
+    RAISE WARNING '[check_and_run_campaigns] Found % campaigns to run. IDs: %',
+        campaigns_to_run, campaign_ids;
+
+    FOR campaign_record IN
+        SELECT * FROM campaigns
+        WHERE id = ANY(campaign_ids)
+    LOOP
+        recipient_count := queue_campaign_messages(campaign_record.id);
+        UPDATE campaigns
+        SET processed = TRUE
+        WHERE id = campaign_record.id;
+
+        seconds_to_add := (recipient_count * 2) + 1200;
+        IF campaign_record.delay IS NOT NULL THEN
+          seconds_to_add := seconds_to_add + campaign_record.delay;
+        END IF;
+        future_timestamp := current_timestamp_utc + (seconds_to_add || ' seconds')::interval;
+        cron_expression :=
+            EXTRACT(MINUTE FROM future_timestamp) || ' ' ||
+            EXTRACT(HOUR FROM future_timestamp) || ' ' ||
+            EXTRACT(DAY FROM future_timestamp) || ' ' ||
+            EXTRACT(MONTH FROM future_timestamp) || ' ' ||
+            '*';
+
+        SELECT decrypted_secret INTO service_key
+        FROM vault.decrypted_secrets
+        WHERE name = 'service_role_key';
+
+        SELECT decrypted_secret INTO edge_url
+        FROM vault.decrypted_secrets
+        WHERE name = 'edge_function_url';
+
+        cron_command := format(
+          'SELECT cron.schedule(
+            ''reconcile-twilio-status'',
+            ''* * * * *'',
+            ''SELECT net.http_post(
+              url:=''''%s/reconcile-twilio-status/'''',
+              body:=''''{"campaignId": %s, "runAt": %s}''''::jsonb,
+              headers:=''''{
+                "Content-Type": "application/json",
+                "Authorization": "Bearer %s"
+                }''''::jsonb)
+            as request_id;''
+          );',
+          edge_url,
+          campaign_record.id,
+          EXTRACT(EPOCH FROM current_timestamp_utc)::INTEGER,
+          service_key
+        );
+
+       PERFORM cron.schedule(
+            'delay-reconcile-twilio-status',
+            cron_expression,
+            cron_command
+        );
+
+        RAISE WARNING '[check_and_run_campaigns] Queued campaign ID: %', campaign_record.id;
+    END LOOP;
+
+    RETURN jsonb_build_object(
+        'status', 'queued',
+        'campaigns_run', campaigns_to_run,
+        'campaign_ids', campaign_ids
+    );
+END;
+$$ LANGUAGE plpgsql;
+--------------------------------------------------------
+ALTER TABLE conversations_labels DROP COLUMN author_phone_number;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -102,17 +102,15 @@ available_labels AS (
     FROM labels
     LIMIT 10  -- Use only first 10 labels
 )
-INSERT INTO conversations_labels (conversation_id, label_id, is_archived, author_phone_number) -- Include author_phone_number here
+INSERT INTO conversations_labels (conversation_id, label_id, is_archived)
 SELECT DISTINCT  -- DISTINCT to avoid duplicates
     c.id,
     l.id,
-    false,
-    ca.author_phone_number -- Populate author_phone_number during insert
+    false
 FROM numbered_conversations c
 CROSS JOIN generate_series(1, 3) n  -- Each conversation gets up to 3 labels
 JOIN available_labels l
     ON l.label_num = (((c.conv_num - 1) * 3 + n) % 10) + 1  -- Distribute labels across conversations
-JOIN conversations_authors ca ON c.id = ca.conversation_id -- Join with conversations_authors
 ON CONFLICT (conversation_id, label_id) DO NOTHING;
 -- Insert data for Campaign
 INSERT INTO campaigns (
@@ -152,7 +150,7 @@ SELECT
     -- Segments JSON with varying configurations
     CASE
         WHEN n % 3 = 0 THEN
-            '{"included": {"id": "' || (SELECT id FROM labels ORDER BY created_at LIMIT 1 OFFSET (n % 10)) || '"}, "excluded": null}'
+            '{"included": {"id": "' || (SELECT id FROM labels ORDER BY created_at LIMIT 1 OFFSET (n % 10)) || '"}}'
         WHEN n % 3 = 1 THEN
             '{"included": [{"id": "' || (SELECT id FROM labels ORDER BY created_at LIMIT 1 OFFSET (n % 10)) || '"}]}'
         ELSE

--- a/supabase/tests/database/get_campaign_recipient_count.sql
+++ b/supabase/tests/database/get_campaign_recipient_count.sql
@@ -1,0 +1,336 @@
+BEGIN;
+
+-- Create a plan for our tests
+SELECT plan(11);
+
+-- Clean up existing test data
+DELETE FROM authors WHERE phone_number LIKE '+999%';
+DELETE FROM conversations WHERE id::text LIKE '00000002-%' OR web_url = 'https://test.com';
+DELETE FROM labels WHERE id::text LIKE '00000001-%';
+
+-- Create test data with proper UUID format
+INSERT INTO labels (id, name)
+VALUES
+  ('00000001-0000-0000-0000-000000000001', 'Test Label 1'),
+  ('00000001-0000-0000-0000-000000000002', 'Test Label 2'),
+  ('00000001-0000-0000-0000-000000000003', 'Test Label 3'),
+  ('00000001-0000-0000-0000-000000000004', 'Test Label 4');
+
+INSERT INTO authors (phone_number, unsubscribed, exclude)
+VALUES
+  ('+9991111111', FALSE, FALSE), -- eligible author 1
+  ('+9992222222', FALSE, FALSE), -- eligible author 2
+  ('+9993333333', FALSE, FALSE), -- eligible author 3
+  ('+9994444444', FALSE, FALSE), -- eligible author 4
+  ('+9995555555', TRUE, FALSE),  -- unsubscribed author
+  ('+9996666666', FALSE, TRUE),  -- excluded author
+  ('+9997777777', FALSE, FALSE); -- eligible author 5 (for later tests)
+
+INSERT INTO conversations (id, web_url, app_url)
+VALUES
+  ('00000002-0000-0000-0000-000000000001', 'https://test.com', 'https://test.com'),
+  ('00000002-0000-0000-0000-000000000002', 'https://test.com', 'https://test.com'),
+  ('00000002-0000-0000-0000-000000000003', 'https://test.com', 'https://test.com'),
+  ('00000002-0000-0000-0000-000000000004', 'https://test.com', 'https://test.com'),
+  ('00000002-0000-0000-0000-000000000005', 'https://test.com', 'https://test.com'),
+  ('00000002-0000-0000-0000-000000000006', 'https://test.com', 'https://test.com'),
+  ('00000002-0000-0000-0000-000000000007', 'https://test.com', 'https://test.com'),
+  ('00000002-0000-0000-0000-000000000008', 'https://test.com', 'https://test.com');
+
+-- Create conversation-label relationships
+INSERT INTO conversations_labels (conversation_id, label_id, is_archived)
+VALUES
+  ('00000002-0000-0000-0000-000000000001', '00000001-0000-0000-0000-000000000001', FALSE),
+  ('00000002-0000-0000-0000-000000000002', '00000001-0000-0000-0000-000000000001', FALSE),
+  ('00000002-0000-0000-0000-000000000003', '00000001-0000-0000-0000-000000000001', FALSE),
+  ('00000002-0000-0000-0000-000000000004', '00000001-0000-0000-0000-000000000001', TRUE),  -- archived, should be excluded
+  ('00000002-0000-0000-0000-000000000005', '00000001-0000-0000-0000-000000000002', FALSE),
+  ('00000002-0000-0000-0000-000000000006', '00000001-0000-0000-0000-000000000002', FALSE),
+  ('00000002-0000-0000-0000-000000000007', '00000001-0000-0000-0000-000000000003', FALSE),
+  ('00000002-0000-0000-0000-000000000008', '00000001-0000-0000-0000-000000000003', FALSE);
+
+-- Create conversation-author relationships
+INSERT INTO conversations_authors (conversation_id, author_phone_number)
+VALUES
+  ('00000002-0000-0000-0000-000000000001', '+9991111111'), -- label 1, eligible
+  ('00000002-0000-0000-0000-000000000002', '+9992222222'), -- label 1, eligible
+  ('00000002-0000-0000-0000-000000000003', '+9993333333'), -- label 1, eligible
+  ('00000002-0000-0000-0000-000000000004', '+9994444444'), -- label 1, but archived
+  ('00000002-0000-0000-0000-000000000005', '+9991111111'), -- label 2, eligible (same as conv-1)
+  ('00000002-0000-0000-0000-000000000006', '+9994444444'), -- label 2, eligible
+  ('00000002-0000-0000-0000-000000000007', '+9995555555'), -- label 3, unsubscribed
+  ('00000002-0000-0000-0000-000000000008', '+9996666666'); -- label 3, excluded
+
+-- Test 1: Single segment
+SELECT is(
+  get_campaign_recipient_count(
+    jsonb_build_object(
+      'included', jsonb_build_object('id', '00000001-0000-0000-0000-000000000001')
+    )
+  ),
+  3,
+  'Single segment should return 3 eligible recipients'
+);
+
+-- Test 2: Multiple segments (OR logic)
+SELECT is(
+  get_campaign_recipient_count(
+    jsonb_build_object(
+      'included', jsonb_build_array(
+        jsonb_build_object('id', '00000001-0000-0000-0000-000000000001'),
+        jsonb_build_object('id', '00000001-0000-0000-0000-000000000002')
+      )
+    )
+  ),
+  4,
+  'Multiple segments with OR logic should return 4 eligible recipients'
+);
+
+-- Test 3: Included and excluded segments
+SELECT is(
+  get_campaign_recipient_count(
+    jsonb_build_object(
+      'included', jsonb_build_object('id', '00000001-0000-0000-0000-000000000001'),
+      'excluded', jsonb_build_object('id', '00000001-0000-0000-0000-000000000002')
+    )
+  ),
+  2,
+  'Label 1 minus Label 2 should return 2 eligible recipients'
+);
+
+-- Test 4: Segment with only unsubscribed or excluded authors
+SELECT is(
+  get_campaign_recipient_count(
+    jsonb_build_object(
+      'included', jsonb_build_object('id', '00000001-0000-0000-0000-000000000003')
+    )
+  ),
+  0,
+  'Segment with only unsubscribed or excluded authors should return 0'
+);
+
+-- Test 5: AND logic (authors with both labels)
+-- First, create an author with both labels
+INSERT INTO conversations (id, web_url, app_url)
+VALUES ('00000002-0000-0000-0000-000000000009', 'https://test.com', 'https://test.com');
+
+INSERT INTO conversations_labels (conversation_id, label_id, is_archived)
+VALUES ('00000002-0000-0000-0000-000000000009', '00000001-0000-0000-0000-000000000001', FALSE);
+
+INSERT INTO conversations_authors (conversation_id, author_phone_number)
+VALUES ('00000002-0000-0000-0000-000000000009', '+9994444444'); -- This author now has both label 1 and label 2
+
+SELECT is(
+  get_campaign_recipient_count(
+    jsonb_build_object(
+      'included', jsonb_build_array(
+        jsonb_build_array(
+          jsonb_build_object('id', '00000001-0000-0000-0000-000000000001'),
+          jsonb_build_object('id', '00000001-0000-0000-0000-000000000002')
+        )
+      )
+    )
+  ),
+  2,
+  'AND logic should return 2 authors who have both labels'
+);
+
+-- Test 6: Complex combination (OR of ANDs)
+-- Create data for this test
+INSERT INTO conversations (id, web_url, app_url)
+VALUES
+  ('00000002-0000-0000-0000-000000000010', 'https://test.com', 'https://test.com'),
+  ('00000002-0000-0000-0000-000000000011', 'https://test.com', 'https://test.com');
+
+INSERT INTO conversations_labels (conversation_id, label_id, is_archived)
+VALUES
+  ('00000002-0000-0000-0000-000000000010', '00000001-0000-0000-0000-000000000002', FALSE),
+  ('00000002-0000-0000-0000-000000000011', '00000001-0000-0000-0000-000000000003', FALSE);
+
+INSERT INTO conversations_authors (conversation_id, author_phone_number)
+VALUES
+  ('00000002-0000-0000-0000-000000000010', '+9997777777'),
+  ('00000002-0000-0000-0000-000000000011', '+9997777777');
+
+SELECT is(
+  get_campaign_recipient_count(
+    jsonb_build_object(
+      'included', jsonb_build_array(
+        jsonb_build_array(
+          jsonb_build_object('id', '00000001-0000-0000-0000-000000000001'),
+          jsonb_build_object('id', '00000001-0000-0000-0000-000000000002')
+        ),
+        jsonb_build_array(
+          jsonb_build_object('id', '00000001-0000-0000-0000-000000000002'),
+          jsonb_build_object('id', '00000001-0000-0000-0000-000000000003')
+        )
+      )
+    )
+  ),
+  3,
+  'OR of ANDs should return 3 authors (2 with labels 1+2, 1 with labels 2+3)'
+);
+
+-- Test 7: Empty result
+SELECT is(
+  get_campaign_recipient_count(
+    jsonb_build_object(
+      'included', jsonb_build_object('id', '00000001-0000-0000-0000-000000000999')
+    )
+  ),
+  0,
+  'Non-existent label should return 0 recipients'
+);
+
+-- Test 8: Since parameter (time filtering)
+-- Reset data for this test to get a clean count
+DELETE FROM conversations_labels WHERE label_id = '00000001-0000-0000-0000-000000000001';
+DELETE FROM conversations_authors WHERE conversation_id IN (
+  '00000002-0000-0000-0000-000000000001',
+  '00000002-0000-0000-0000-000000000002',
+  '00000002-0000-0000-0000-000000000003',
+  '00000002-0000-0000-0000-000000000004',
+  '00000002-0000-0000-0000-000000000009'
+);
+
+-- Insert older data (created more than 1 hour ago)
+INSERT INTO conversations_labels (conversation_id, label_id, is_archived, created_at)
+VALUES
+  ('00000002-0000-0000-0000-000000000001', '00000001-0000-0000-0000-000000000001', FALSE, CURRENT_TIMESTAMP - INTERVAL '2 hours'),
+  ('00000002-0000-0000-0000-000000000002', '00000001-0000-0000-0000-000000000001', FALSE, CURRENT_TIMESTAMP - INTERVAL '2 hours'),
+  ('00000002-0000-0000-0000-000000000003', '00000001-0000-0000-0000-000000000001', FALSE, CURRENT_TIMESTAMP - INTERVAL '2 hours');
+
+INSERT INTO conversations_authors (conversation_id, author_phone_number)
+VALUES
+  ('00000002-0000-0000-0000-000000000001', '+9991111111'),
+  ('00000002-0000-0000-0000-000000000002', '+9992222222'),
+  ('00000002-0000-0000-0000-000000000003', '+9993333333');
+
+-- Insert newer data (created less than 1 hour ago)
+INSERT INTO conversations (id, web_url, app_url)
+VALUES ('00000002-0000-0000-0000-000000000012', 'https://test.com', 'https://test.com');
+
+INSERT INTO conversations_labels (conversation_id, label_id, is_archived, created_at)
+VALUES ('00000002-0000-0000-0000-000000000012', '00000001-0000-0000-0000-000000000001', FALSE, CURRENT_TIMESTAMP);
+
+INSERT INTO conversations_authors (conversation_id, author_phone_number)
+VALUES ('00000002-0000-0000-0000-000000000012', '+9997777777');
+
+-- Use a timestamp from 1 hour ago
+SELECT is(
+  get_campaign_recipient_count(
+    jsonb_build_object(
+      'included', jsonb_build_object(
+        'id', '00000001-0000-0000-0000-000000000001',
+        'since', EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - INTERVAL '1 hour'))::INTEGER
+      )
+    )
+  ),
+  1,
+  'Label with since parameter should only include recent conversations'
+);
+
+-- Test 9: Excluded authors should not be counted
+-- Reset data for a clean test
+DELETE FROM conversations_labels WHERE label_id = '00000001-0000-0000-0000-000000000001';
+DELETE FROM conversations_authors WHERE conversation_id IN (
+  '00000002-0000-0000-0000-000000000001',
+  '00000002-0000-0000-0000-000000000002',
+  '00000002-0000-0000-0000-000000000003',
+  '00000002-0000-0000-0000-000000000012'
+);
+
+-- Insert baseline data - 3 eligible authors
+INSERT INTO conversations_labels (conversation_id, label_id, is_archived)
+VALUES
+  ('00000002-0000-0000-0000-000000000001', '00000001-0000-0000-0000-000000000001', FALSE),
+  ('00000002-0000-0000-0000-000000000002', '00000001-0000-0000-0000-000000000001', FALSE),
+  ('00000002-0000-0000-0000-000000000003', '00000001-0000-0000-0000-000000000001', FALSE);
+
+INSERT INTO conversations_authors (conversation_id, author_phone_number)
+VALUES
+  ('00000002-0000-0000-0000-000000000001', '+9991111111'),
+  ('00000002-0000-0000-0000-000000000002', '+9992222222'),
+  ('00000002-0000-0000-0000-000000000003', '+9993333333');
+
+-- Add an excluded author to the same label
+INSERT INTO conversations (id, web_url, app_url)
+VALUES ('00000002-0000-0000-0000-000000000013', 'https://test.com', 'https://test.com');
+
+INSERT INTO conversations_labels (conversation_id, label_id, is_archived)
+VALUES ('00000002-0000-0000-0000-000000000013', '00000001-0000-0000-0000-000000000001', FALSE);
+
+INSERT INTO conversations_authors (conversation_id, author_phone_number)
+VALUES ('00000002-0000-0000-0000-000000000013', '+9996666666'); -- excluded author
+
+SELECT is(
+  get_campaign_recipient_count(
+    jsonb_build_object(
+      'included', jsonb_build_object('id', '00000001-0000-0000-0000-000000000001')
+    )
+  ),
+  3, -- still 3, not 4, because the new author is excluded
+  'Excluded authors should not be counted'
+);
+
+-- Test 10: Unsubscribed authors should not be counted
+-- Add an unsubscribed author to the same label
+INSERT INTO conversations (id, web_url, app_url)
+VALUES ('00000002-0000-0000-0000-000000000014', 'https://test.com', 'https://test.com');
+
+INSERT INTO conversations_labels (conversation_id, label_id, is_archived)
+VALUES ('00000002-0000-0000-0000-000000000014', '00000001-0000-0000-0000-000000000001', FALSE);
+
+INSERT INTO conversations_authors (conversation_id, author_phone_number)
+VALUES ('00000002-0000-0000-0000-000000000014', '+9995555555'); -- unsubscribed author
+
+SELECT is(
+  get_campaign_recipient_count(
+    jsonb_build_object(
+      'included', jsonb_build_object('id', '00000001-0000-0000-0000-000000000001')
+    )
+  ),
+  3, -- still 3, not 4, because the new author is unsubscribed
+  'Unsubscribed authors should not be counted'
+);
+
+-- Test 11: Label with mixed eligible and ineligible authors
+-- Create a new label with both eligible and ineligible authors
+DELETE FROM conversations_labels WHERE label_id = '00000001-0000-0000-0000-000000000004';
+DELETE FROM conversations_authors WHERE conversation_id IN (
+  '00000002-0000-0000-0000-000000000015',
+  '00000002-0000-0000-0000-000000000016',
+  '00000002-0000-0000-0000-000000000017'
+);
+
+INSERT INTO conversations (id, web_url, app_url)
+VALUES
+  ('00000002-0000-0000-0000-000000000015', 'https://test.com', 'https://test.com'),
+  ('00000002-0000-0000-0000-000000000016', 'https://test.com', 'https://test.com'),
+  ('00000002-0000-0000-0000-000000000017', 'https://test.com', 'https://test.com');
+
+INSERT INTO conversations_labels (conversation_id, label_id, is_archived)
+VALUES
+  ('00000002-0000-0000-0000-000000000015', '00000001-0000-0000-0000-000000000004', FALSE),
+  ('00000002-0000-0000-0000-000000000016', '00000001-0000-0000-0000-000000000004', FALSE),
+  ('00000002-0000-0000-0000-000000000017', '00000001-0000-0000-0000-000000000004', FALSE);
+
+INSERT INTO conversations_authors (conversation_id, author_phone_number)
+VALUES
+  ('00000002-0000-0000-0000-000000000015', '+9991111111'), -- eligible
+  ('00000002-0000-0000-0000-000000000016', '+9995555555'), -- unsubscribed
+  ('00000002-0000-0000-0000-000000000017', '+9996666666'); -- excluded
+
+SELECT is(
+  get_campaign_recipient_count(
+    jsonb_build_object(
+      'included', jsonb_build_object('id', '00000001-0000-0000-0000-000000000004')
+    )
+  ),
+  1, -- Only 1 eligible author out of 3 total
+  'Label with mixed eligible and ineligible authors should only count eligible ones'
+);
+
+-- Clean up
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/queue_campaign_messages.sql
+++ b/supabase/tests/database/queue_campaign_messages.sql
@@ -1,0 +1,310 @@
+BEGIN;
+
+-- Create a plan for our tests
+SELECT plan(7);
+
+-- Helper function to count messages in the queue for a specific campaign
+CREATE OR REPLACE FUNCTION count_queued_messages(p_campaign_id INTEGER) RETURNS INTEGER AS $$
+DECLARE
+    v_count INTEGER;
+BEGIN
+    SELECT COUNT(*)
+    INTO v_count
+    FROM pgmq.q_broadcast_first_messages
+    WHERE message::jsonb->>'campaign_id' = p_campaign_id::TEXT;
+
+    RETURN v_count;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Helper function to count messages for specific phone numbers
+CREATE OR REPLACE FUNCTION count_queued_messages_for_phones(p_campaign_id INTEGER, p_phone_numbers TEXT[]) RETURNS INTEGER AS $$
+DECLARE
+    v_count INTEGER;
+BEGIN
+    SELECT COUNT(*)
+    INTO v_count
+    FROM pgmq.q_broadcast_first_messages
+    WHERE
+        message::jsonb->>'campaign_id' = p_campaign_id::TEXT
+        AND message::jsonb->>'recipient_phone_number' = ANY(p_phone_numbers);
+
+    RETURN v_count;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Clean any existing test messages from the queue
+DELETE FROM pgmq.q_broadcast_first_messages WHERE message::jsonb->>'campaign_id' IN ('10001', '10002', '10003', '10004', '10005');
+
+-- Clean up any temporary tables that might exist from previous runs
+DROP TABLE IF EXISTS campaign_recipients_temp;
+
+-- Test 1: Basic test - Create a campaign with a segment that has 3 eligible authors
+-- First clean up any existing test data
+DELETE FROM conversations_authors WHERE conversation_id IN (
+    '00000002-0000-0000-0000-000000000001',
+    '00000002-0000-0000-0000-000000000002',
+    '00000002-0000-0000-0000-000000000003',
+    '00000002-0000-0000-0000-000000000004',
+    '00000002-0000-0000-0000-000000000005',
+    '00000002-0000-0000-0000-000000000006',
+    '00000002-0000-0000-0000-000000000007',
+    '00000002-0000-0000-0000-000000000008',
+    '00000002-0000-0000-0000-000000000009'
+);
+DELETE FROM conversations_labels WHERE conversation_id IN (
+    '00000002-0000-0000-0000-000000000001',
+    '00000002-0000-0000-0000-000000000002',
+    '00000002-0000-0000-0000-000000000003',
+    '00000002-0000-0000-0000-000000000004',
+    '00000002-0000-0000-0000-000000000005',
+    '00000002-0000-0000-0000-000000000006',
+    '00000002-0000-0000-0000-000000000007',
+    '00000002-0000-0000-0000-000000000008',
+    '00000002-0000-0000-0000-000000000009'
+);
+DELETE FROM conversations WHERE id IN (
+    '00000002-0000-0000-0000-000000000001',
+    '00000002-0000-0000-0000-000000000002',
+    '00000002-0000-0000-0000-000000000003',
+    '00000002-0000-0000-0000-000000000004',
+    '00000002-0000-0000-0000-000000000005',
+    '00000002-0000-0000-0000-000000000006',
+    '00000002-0000-0000-0000-000000000007',
+    '00000002-0000-0000-0000-000000000008',
+    '00000002-0000-0000-0000-000000000009'
+);
+DELETE FROM authors WHERE phone_number LIKE '+999%';
+DELETE FROM labels WHERE id IN (
+    '00000001-0000-0000-0000-000000000001',
+    '00000001-0000-0000-0000-000000000002',
+    '00000001-0000-0000-0000-000000000003',
+    '00000001-0000-0000-0000-000000000004'
+);
+DELETE FROM campaigns WHERE id IN (10001, 10002, 10003, 10004, 10005);
+
+-- Create test data for label 1 with 3 eligible authors
+INSERT INTO labels (id, name)
+VALUES ('00000001-0000-0000-0000-000000000001', 'Test Label 1');
+
+INSERT INTO authors (phone_number, unsubscribed, exclude)
+VALUES
+  ('+9991111111', FALSE, FALSE), -- eligible author 1
+  ('+9992222222', FALSE, FALSE), -- eligible author 2
+  ('+9993333333', FALSE, FALSE), -- eligible author 3
+  ('+9994444444', FALSE, FALSE), -- eligible author 4
+  ('+9995555555', TRUE, FALSE),  -- unsubscribed author
+  ('+9996666666', FALSE, TRUE);  -- excluded author
+
+INSERT INTO conversations (id, web_url, app_url)
+VALUES
+  ('00000002-0000-0000-0000-000000000001', 'https://test.com', 'https://test.com'),
+  ('00000002-0000-0000-0000-000000000002', 'https://test.com', 'https://test.com'),
+  ('00000002-0000-0000-0000-000000000003', 'https://test.com', 'https://test.com');
+
+INSERT INTO conversations_labels (conversation_id, label_id, is_archived)
+VALUES
+  ('00000002-0000-0000-0000-000000000001', '00000001-0000-0000-0000-000000000001', FALSE),
+  ('00000002-0000-0000-0000-000000000002', '00000001-0000-0000-0000-000000000001', FALSE),
+  ('00000002-0000-0000-0000-000000000003', '00000001-0000-0000-0000-000000000001', FALSE);
+
+INSERT INTO conversations_authors (conversation_id, author_phone_number)
+VALUES
+  ('00000002-0000-0000-0000-000000000001', '+9991111111'),
+  ('00000002-0000-0000-0000-000000000002', '+9992222222'),
+  ('00000002-0000-0000-0000-000000000003', '+9993333333');
+
+INSERT INTO campaigns (id, title, first_message, second_message, run_at, segments, delay)
+VALUES (
+    10001,
+    'Test Campaign 1',
+    'First message text',
+    'Second message text',
+    CURRENT_TIMESTAMP + INTERVAL '1 day',
+    jsonb_build_object(
+        'included', jsonb_build_object('id', '00000001-0000-0000-0000-000000000001')
+    ),
+    600
+);
+
+SELECT lives_ok(
+    'SELECT queue_campaign_messages(10001)',
+    'queue_campaign_messages executes successfully with single segment'
+);
+
+SELECT is(
+    count_queued_messages(10001),
+    3,
+    'Campaign with single segment queued 3 messages (excluding archived/unsubscribed/excluded)'
+);
+
+-- Explicitly drop the temporary table after each test
+DROP TABLE IF EXISTS campaign_recipients_temp;
+
+-- Test 2: Campaign with multiple segments (OR logic)
+INSERT INTO labels (id, name)
+VALUES ('00000001-0000-0000-0000-000000000002', 'Test Label 2');
+
+INSERT INTO conversations (id, web_url, app_url)
+VALUES
+  ('00000002-0000-0000-0000-000000000004', 'https://test.com', 'https://test.com'),
+  ('00000002-0000-0000-0000-000000000005', 'https://test.com', 'https://test.com');
+
+INSERT INTO conversations_labels (conversation_id, label_id, is_archived)
+VALUES
+  ('00000002-0000-0000-0000-000000000004', '00000001-0000-0000-0000-000000000002', FALSE),
+  ('00000002-0000-0000-0000-000000000005', '00000001-0000-0000-0000-000000000002', FALSE);
+
+INSERT INTO conversations_authors (conversation_id, author_phone_number)
+VALUES
+  ('00000002-0000-0000-0000-000000000004', '+9993333333'), -- already has label 1
+  ('00000002-0000-0000-0000-000000000005', '+9994444444'); -- new author
+
+INSERT INTO campaigns (id, title, first_message, second_message, run_at, segments, delay)
+VALUES (
+    10002,
+    'Test Campaign 2',
+    'First message text',
+    'Second message text',
+    CURRENT_TIMESTAMP + INTERVAL '1 day',
+    jsonb_build_object(
+        'included', jsonb_build_array(
+            jsonb_build_object('id', '00000001-0000-0000-0000-000000000001'),
+            jsonb_build_object('id', '00000001-0000-0000-0000-000000000002')
+        )
+    ),
+    600
+);
+
+SELECT queue_campaign_messages(10002);
+
+SELECT is(
+    count_queued_messages(10002),
+    4,
+    'Campaign with multiple segments queued 4 messages (unique eligible recipients)'
+);
+
+-- Explicitly drop the temporary table after each test
+DROP TABLE IF EXISTS campaign_recipients_temp;
+
+-- Test 3: Campaign with included and excluded segments
+INSERT INTO campaigns (id, title, first_message, second_message, run_at, segments, delay)
+VALUES (
+    10003,
+    'Test Campaign 3',
+    'First message text',
+    'Second message text',
+    CURRENT_TIMESTAMP + INTERVAL '1 day',
+    jsonb_build_object(
+        'included', jsonb_build_object('id', '00000001-0000-0000-0000-000000000001'),
+        'excluded', jsonb_build_object('id', '00000001-0000-0000-0000-000000000002')
+    ),
+    600
+);
+
+SELECT queue_campaign_messages(10003);
+
+SELECT is(
+    count_queued_messages(10003),
+    2,
+    'Campaign with excluded segment queued 2 messages (after excluding overlapping recipients)'
+);
+
+-- Explicitly drop the temporary table after each test
+DROP TABLE IF EXISTS campaign_recipients_temp;
+
+-- Test 4: Verify the campaign recipient_count is updated
+SELECT is(
+    (SELECT recipient_count FROM campaigns WHERE id = 10003),
+    2,
+    'Campaign recipient_count field is updated correctly'
+);
+
+-- Test 5: Explicitly verify unsubscribed users are not included
+INSERT INTO labels (id, name)
+VALUES ('00000001-0000-0000-0000-000000000003', 'Test Label 3');
+
+INSERT INTO conversations (id, web_url, app_url)
+VALUES ('00000002-0000-0000-0000-000000000006', 'https://test.com', 'https://test.com');
+
+INSERT INTO conversations_labels (conversation_id, label_id, is_archived)
+VALUES ('00000002-0000-0000-0000-000000000006', '00000001-0000-0000-0000-000000000003', FALSE);
+
+INSERT INTO conversations_authors (conversation_id, author_phone_number)
+VALUES ('00000002-0000-0000-0000-000000000006', '+9995555555');
+
+INSERT INTO campaigns (id, title, first_message, second_message, run_at, segments, delay)
+VALUES (
+    10004,
+    'Test Campaign 4',
+    'First message text',
+    'Second message text',
+    CURRENT_TIMESTAMP + INTERVAL '1 day',
+    jsonb_build_object(
+        'included', jsonb_build_object('id', '00000001-0000-0000-0000-000000000003')
+    ),
+    600
+);
+
+SELECT queue_campaign_messages(10004);
+
+SELECT is(
+    count_queued_messages(10004),
+    0,
+    'Campaign targeting only unsubscribed authors queues 0 messages'
+);
+
+-- Explicitly drop the temporary table after each test
+DROP TABLE IF EXISTS campaign_recipients_temp;
+
+-- Test 6: Explicitly verify that unsubscribed/excluded users are filtered out
+INSERT INTO labels (id, name)
+VALUES ('00000001-0000-0000-0000-000000000004', 'Test Label 4');
+
+INSERT INTO conversations (id, web_url, app_url)
+VALUES
+  ('00000002-0000-0000-0000-000000000007', 'https://test.com', 'https://test.com'),
+  ('00000002-0000-0000-0000-000000000008', 'https://test.com', 'https://test.com'),
+  ('00000002-0000-0000-0000-000000000009', 'https://test.com', 'https://test.com');
+
+INSERT INTO conversations_labels (conversation_id, label_id, is_archived)
+VALUES
+  ('00000002-0000-0000-0000-000000000007', '00000001-0000-0000-0000-000000000004', FALSE),
+  ('00000002-0000-0000-0000-000000000008', '00000001-0000-0000-0000-000000000004', FALSE),
+  ('00000002-0000-0000-0000-000000000009', '00000001-0000-0000-0000-000000000004', FALSE);
+
+INSERT INTO conversations_authors (conversation_id, author_phone_number)
+VALUES
+  ('00000002-0000-0000-0000-000000000007', '+9991111111'), -- eligible
+  ('00000002-0000-0000-0000-000000000008', '+9995555555'), -- unsubscribed
+  ('00000002-0000-0000-0000-000000000009', '+9996666666'); -- excluded
+
+INSERT INTO campaigns (id, title, first_message, second_message, run_at, segments, delay)
+VALUES (
+    10005,
+    'Test Campaign 5',
+    'First message text',
+    'Second message text',
+    CURRENT_TIMESTAMP + INTERVAL '1 day',
+    jsonb_build_object(
+        'included', jsonb_build_object('id', '00000001-0000-0000-0000-000000000004')
+    ),
+    600
+);
+
+SELECT queue_campaign_messages(10005);
+
+-- Combined test for both cases
+SELECT is(
+    count_queued_messages_for_phones(10005, ARRAY['+9995555555', '+9996666666']),
+    0,
+    'No messages are queued for unsubscribed or excluded authors'
+);
+
+-- Explicitly drop the temporary table after the final test
+DROP TABLE IF EXISTS campaign_recipients_temp;
+
+-- Clean up
+DELETE FROM pgmq.q_broadcast_first_messages WHERE message::jsonb->>'campaign_id' IN ('10001', '10002', '10003', '10004', '10005');
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Co-authored-by: Thuan Ngo <thuan.ngo@eastagile.com>

[OUT-320](https://linear.app/pdw/issue/OUT-320/archive-conversations-with-two-consecutive-failed-broadcast-sms)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add archiving for conversations with two failed SMS deliveries and refactor campaign recipient counting logic.
> 
>   - **New Features**:
>     - Add `ARCHIVE_MESSAGE` constant in `constants.ts` for archiving messages after two failed deliveries.
>     - Introduce `ARCHIVE_BROADCAST_DOUBLE_FAILURES_CRON` in `cron.ts` to schedule archiving of failed broadcasts.
>     - Add `BROADCAST_DOUBLE_FAILURE_QUERY` in `queries.ts` to identify double failures.
>     - Implement `archiveBroadcastDoubleFailures()` in `BroadcastService.ts` to handle archiving logic.
>   - **Refactor**:
>     - Remove `authorPhoneNumber` from `conversationsLabels` in `schema.ts`.
>     - Update `upsertLabel()` in `utils.ts` to remove `authorPhoneNumber` handling.
>     - Simplify `campaigns/index.ts` by removing unnecessary joins and fields.
>   - **Bug Fixes**:
>     - Fix handling of label upserts to use comprehensive request data in `utils.ts`.
>     - Remove redundant index creation in `schema.ts` and `0000_minor_magik.sql`.
>   - **Tests**:
>     - Add tests for `get_campaign_recipient_count.sql` and `queue_campaign_messages.sql` to verify new logic.
>     - Update `campaigns-tests.ts` to reflect changes in recipient counting and archiving logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PublicDataWorks%2Ftxt-outlier-backend&utm_source=github&utm_medium=referral)<sup> for 6f3c1fc41595a061729f61d0b1e0a0bf2eb7a2d0. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a constant for archiving messages when the last two messages didn't go through.
  - Introduced a new SQL query to identify and manage broadcast double failures in message delivery.
  - Enhanced campaign management with new functions for recipient counting and message queuing.
  - Added a new function to archive broadcast double failures.
  
- **Bug Fixes**
  - Removed unnecessary fields and improved the structure of conversations and labels for better data handling.

- **Refactor**
  - Streamlined internal processes and scheduling logic for messaging and campaign workflows for greater reliability.
  - Updated handling of label upserts to utilize comprehensive request data.
  - Simplified the schema by removing redundant references and index creation.

- **Chores**
  - Added configuration files for managing dependencies and project settings.
  - Introduced a new migration file for campaign recipient counting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->