### PR TITLE
OUT-362 - Enhance GET Campaign API to Include Reply Count for Past Campaigns

### DIFF
--- a/supabase/functions/_shared/drizzle/schema.ts
+++ b/supabase/functions/_shared/drizzle/schema.ts
@@ -288,8 +288,9 @@ export const twilioMessages = pgTable('twilio_messages', {
   attachments: text('attachments'),
   fromField: text('from_field').notNull().references(() => authors.phoneNumber),
   toField: text('to_field').notNull().references(() => authors.phoneNumber),
-  isBroadcastReply: boolean('is_broadcast_reply').default(false).notNull(),
+  isReply: boolean('is_reply').default(false).notNull(),
   replyToBroadcast: bigint('reply_to_broadcast', { mode: 'number' }),
+  replyToCampaign: bigint('reply_to_campaign', { mode: 'number' }),
   senderId: uuid('sender_id').references(() => users.id, { onDelete: 'cascade' }),
 }, (table) => {
   return {

--- a/supabase/functions/_shared/scheduledcron/queries.ts
+++ b/supabase/functions/_shared/scheduledcron/queries.ts
@@ -165,6 +165,15 @@ function getPastCampaignsWithStatsQuery(page: number, pageSize: number) {
       JOIN message_statuses ms ON um.reply_to = ms.id
       WHERE ms.campaign_id IN (SELECT id FROM past_campaigns)
       GROUP BY ms.campaign_id
+    ),
+    replies AS (
+      SELECT
+        reply_to_campaign AS campaign_id,
+        COUNT(*) AS total_replies
+      FROM twilio_messages
+      WHERE reply_to_campaign IS NOT NULL
+        AND reply_to_campaign IN (SELECT id FROM past_campaigns)
+      GROUP BY reply_to_campaign
     )
     SELECT
       pc.*,
@@ -172,13 +181,15 @@ function getPastCampaignsWithStatsQuery(page: number, pageSize: number) {
       COALESCE(smc.total_second, 0) AS "secondMessageCount",
       COALESCE(sd.total_success, 0) AS "successfulDeliveries",
       COALESCE(fd.total_failed, 0) AS "failedDeliveries",
-      COALESCE(u.total_unsub, 0) AS "unsubscribes"
+      COALESCE(u.total_unsub, 0) AS "unsubscribes",
+      COALESCE(r.total_replies, 0) AS "no_of_replies"
     FROM past_campaigns pc
     LEFT JOIN first_message_counts fmc ON pc.id = fmc.campaign_id
     LEFT JOIN second_message_counts smc ON pc.id = smc.campaign_id
     LEFT JOIN successful_deliveries sd ON pc.id = sd.campaign_id
     LEFT JOIN failed_deliveries fd ON pc.id = fd.campaign_id
     LEFT JOIN unsubscribes u ON pc.id = u.campaign_id
+    LEFT JOIN replies r ON pc.id = r.campaign_id
     ORDER BY pc."runAt" DESC
   `
 }

--- a/supabase/functions/_shared/scheduledcron/queries.ts
+++ b/supabase/functions/_shared/scheduledcron/queries.ts
@@ -217,7 +217,7 @@ const FAILED_DELIVERED_QUERY = `
       SELECT 1 FROM conversations_labels cl
       WHERE
         cl.conversation_id = r.missive_conversation_id
-        AND cl.label_id = ${Deno.env.get('MISSIVE_REPLY_LABEL_ID')!}
+        AND cl.label_id = '${Deno.env.get('MISSIVE_REPLY_LABEL_ID')!}'
         AND cl.is_archived = FALSE
     )
   GROUP BY r.recipient_phone_number

--- a/supabase/functions/tests/factories/twilio-message.ts
+++ b/supabase/functions/tests/factories/twilio-message.ts
@@ -1,0 +1,56 @@
+// twilio-message.ts
+import { twilioMessages } from '../../_shared/drizzle/schema.ts'
+import supabase from '../../_shared/lib/supabase.ts'
+
+type CreateTwilioMessageParams = {
+  preview?: string
+  type?: string
+  deliveredAt?: string
+  updatedAt?: string
+  references?: string[]
+  externalId?: string
+  attachments?: string
+  fromField: string
+  toField: string
+  isReply?: boolean
+  replyToBroadcast?: number
+  replyToCampaign?: number
+  senderId?: string
+}
+
+export async function createTwilioMessage({
+  preview = 'Message preview',
+  type,
+  deliveredAt = new Date().toISOString(),
+  updatedAt,
+  references = [],
+  externalId,
+  attachments,
+  fromField,
+  toField,
+  isReply = false,
+  replyToBroadcast,
+  replyToCampaign,
+  senderId,
+}: CreateTwilioMessageParams) {
+  const [twilioMessage] = await supabase
+    .insert(twilioMessages)
+    .values({
+      preview,
+      type,
+      deliveredAt,
+      updatedAt,
+      references,
+      externalId,
+      attachments,
+      fromField,
+      toField,
+      isReply,
+      replyToBroadcast,
+      replyToCampaign,
+      senderId,
+    })
+    .returning()
+
+  return twilioMessage
+}

--- a/supabase/functions/tests/setup.ts
+++ b/supabase/functions/tests/setup.ts
@@ -17,6 +17,9 @@ beforeEach(async () => {
     '../../migrations/20250304080718_add_recipient_count_to_campaigns.sql',
     '../../migrations/20250306085822_count_campaign_recipient_using_conversations_authors_table.sql',
     '../../migrations/20250310074006_add_file_based_campaigns.sql',
+    '../../migrations/20250312074137_add_daily_broadcast_reconciliation_function.sql',
+    '../../migrations/20250317043943_campaign_should_not_run_reconcile_status.sql',
+    '../../migrations/20250318043746_add_reply_to_campaign_to_twilio_messages.sql',
   ]
 
   for (const filePath of migrationFiles) {

--- a/supabase/functions/tests/user-action-tests/broadcast-reply-tests.ts
+++ b/supabase/functions/tests/user-action-tests/broadcast-reply-tests.ts
@@ -45,7 +45,7 @@ describe(
 
       const incomingMessages = await supabase.select().from(twilioMessages)
       assertEquals(incomingMessages.length, 1)
-      assert(incomingMessages[0].isBroadcastReply)
+      assert(incomingMessages[0].isReply)
     })
   },
 )

--- a/supabase/functions/user-actions/handlers/broadcast-handlers.ts
+++ b/supabase/functions/user-actions/handlers/broadcast-handlers.ts
@@ -79,13 +79,12 @@ const handleBroadcastReply = async (requestBody: RequestBody) => {
 
     const sentMessage = await findRecentBroadcastOrCampaignMessage(phoneNumber, deliveredDate)
     if (sentMessage.length > 0) {
-      // Update Twilio message with broadcast reply info
-      // TODO: rename isBroadcastReply and replyToBroadcast
       await supabase
         .update(twilioMessages)
         .set({
-          isBroadcastReply: true,
+          isReply: true,
           replyToBroadcast: sentMessage[0].broadcastId || sentMessage[0].campaignId,
+          replyToCampaign: sentMessage[0].broadcastId || sentMessage[0].campaignId,
         })
         .where(eq(twilioMessages.id, requestMessage.id))
 

--- a/supabase/migrations/20250318043746_add_reply_to_campaign_to_twilio_messages.sql
+++ b/supabase/migrations/20250318043746_add_reply_to_campaign_to_twilio_messages.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "twilio_messages" ADD COLUMN "reply_to_campaign" BIGINT;
+ALTER TABLE "twilio_messages" RENAME COLUMN "is_broadcast_reply" TO "is_reply";


### PR DESCRIPTION
Co-authored-by: Thuan Ngo <thuan.ngo@eastagile.com>

[OUT-362](https://linear.app/pdw/issue/OUT-362/enhance-get-campaign-api-to-include-reply-count-for-past-campaigns)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced reply tracking to now include campaign-associated responses.
	- Campaign reports now display updated reply counts for past campaigns.
- **Tests**
	- Added new test cases to verify the accuracy of reply count measurements in campaign analytics.
	- Updated existing tests to reflect changes in reply property naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->