### PR TITLE
Correctly handle new name for outgoing sms rule

### DIFF
--- a/supabase/functions/tests/factories/user.ts
+++ b/supabase/functions/tests/factories/user.ts
@@ -1,0 +1,17 @@
+import { User, users } from '../../_shared/drizzle/schema.ts'
+import supabase from '../../_shared/lib/supabase.ts'
+
+export async function createUser(overrides: Partial<User> = {}): Promise<User> {
+  const userData: User = {
+    id: crypto.randomUUID(),
+    name: `Test User ${Date.now()}`,
+    email: `test-${Date.now()}@example.com`,
+    avatarUrl: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  }
+
+  await supabase.insert(users).values(userData)
+  return userData
+}

--- a/supabase/functions/tests/fixtures/outgoing-twilio-message-request.ts
+++ b/supabase/functions/tests/fixtures/outgoing-twilio-message-request.ts
@@ -1,0 +1,92 @@
+import { RequestBody, RuleType } from '../../user-actions/types.ts'
+
+export const newOutgoingSmsRequest: RequestBody = {
+  rule: {
+    id: '72e519db-e6ad-46ff-b8b7-a0b5a8275a5f',
+    description: 'Outgoing SMS',
+    type: RuleType.OutgoingSmsMessage,
+  },
+  conversation: {
+    id: '410ca243-af1e-475e-9a20-a86502d9ad2e',
+    created_at: 1707452590,
+    subject: null,
+    latest_message_subject: 'SMS with +11234567891',
+    organization: {
+      id: '7deec8a7-439a-414c-a10a-059142216786',
+      name: 'Outlier Staging',
+    },
+    // @ts-ignore
+    color: null,
+    authors: [
+      { name: '+11234567890', phone_number: '+11234567890' },
+      { name: '+11234567891', phone_number: '+11234567891' },
+    ],
+    external_authors: [{ name: '+11234567891', phone_number: '+11234567891' }],
+    messages_count: 161,
+    drafts_count: 0,
+    send_later_messages_count: 0,
+    attachments_count: 0,
+    tasks_count: 0,
+    completed_tasks_count: 0,
+    users: [
+      {
+        id: '2d98b928-c3be-4cc6-8087-0baa2235e86e',
+        name: 'User 1',
+        email: 'user@mail.com',
+        unassigned: true,
+        closed: false,
+        archived: false,
+        trashed: false,
+        junked: false,
+        assigned: false,
+        flagged: false,
+        snoozed: false,
+      },
+    ],
+    assignees: [],
+    assignee_names: '',
+    assignee_emails: '',
+    shared_label_names: '',
+    web_url: 'https://mail.missiveapp.com/#inbox/conversations/410ca243-af1e-475e-9a20-a86502d9ad2e',
+    app_url: 'missive://mail.missiveapp.com/#inbox/conversations/410ca243-af1e-475e-9a20-a86502d9ad2e',
+    team: {
+      id: 'fb0b601e-7d6e-4248-8882-4f129fdfe43c',
+      name: 'Outlier Staging',
+      organization: '7deec8a7-439a-414c-a10a-059142216786',
+    },
+    shared_labels: [],
+  },
+  message: {
+    id: '972358ad-eda6-4936-9ff4-63fe7c178241',
+    preview: 'Hello from outgoing message',
+    type: 'sms',
+    delivered_at: 1708418458,
+    updated_at: 1708418458,
+    created_at: 1708418458,
+    references: ['+11234567890+11234567891'],
+    // Outgoing message from our number to customer
+    from_field: { id: '+11234567890', name: '+11234567890', username: null },
+    to_fields: [
+      { id: '+11234567891', name: '+11234567891', username: null },
+    ],
+    external_id: 'SMd76fc9e0453e8bfd0d78623e40437223',
+    account_author: { id: '+11234567890', name: '+11234567890', username: null },
+    account_recipients: [
+      { id: '+11234567891', name: '+11234567891', username: null },
+    ],
+    attachments: [],
+    author: {
+      id: 'sender-user-id-123',
+    },
+  },
+}
+
+// Also create an outgoing Twilio message variant
+export const newOutgoingTwilioRequest: RequestBody = {
+  ...newOutgoingSmsRequest,
+  rule: {
+    id: '72e519db-e6ad-46ff-b8b7-a0b5a8275a5f',
+    description: 'Outgoing Twilio',
+    type: RuleType.OutgoingTwilioMessage,
+  },
+}

--- a/supabase/functions/tests/user-action-tests/twilio-message-handler-tests.ts
+++ b/supabase/functions/tests/user-action-tests/twilio-message-handler-tests.ts
@@ -3,10 +3,12 @@ import { assertEquals } from 'jsr:@std/assert'
 import { eq } from 'drizzle-orm'
 
 import '../setup.ts'
-import { authors } from '../../_shared/drizzle/schema.ts'
+import { authors, twilioMessages } from '../../_shared/drizzle/schema.ts'
 import { newIncomingSmsRequest } from '../fixtures/incoming-twilio-message-request.ts'
+import { newOutgoingSmsRequest, newOutgoingTwilioRequest } from '../fixtures/outgoing-twilio-message-request.ts'
 import supabase from '../../_shared/lib/supabase.ts'
 import { client } from '../utils.ts'
+import { createUser } from '../factories/user.ts'
 
 const FUNCTION_NAME = 'user-actions/'
 
@@ -93,6 +95,95 @@ describe(
         .from(authors)
         .where(eq(authors.phoneNumber, phoneNumber))
       assertEquals(authorAfter[0].unsubscribed, true)
+    })
+  },
+)
+
+describe(
+  'Twilio Message senderId assignment',
+  { sanitizeOps: false, sanitizeResources: false },
+  () => {
+    it('does not set senderId for incoming messages', async () => {
+      const requestData = structuredClone(newIncomingSmsRequest)
+
+      // Generate a valid UUID for the message ID
+      const messageId = crypto.randomUUID()
+      requestData.message!.id = messageId
+
+      // Make the request to process the message
+      await client.functions.invoke(FUNCTION_NAME, {
+        method: 'POST',
+        body: requestData,
+      })
+
+      // Find the inserted message
+      const [message] = await supabase
+        .select()
+        .from(twilioMessages)
+        .where(eq(twilioMessages.id, messageId))
+        .limit(1)
+
+      // Verify senderId is not set (undefined/null)
+      assertEquals(message.senderId, null)
+    })
+
+    it('sets senderId for outgoing SMS messages', async () => {
+      // Create a valid user first
+      const testUser = await createUser()
+      const requestData = structuredClone(newOutgoingSmsRequest)
+
+      // Generate a valid UUID for the message ID
+      const messageId = crypto.randomUUID()
+      requestData.message!.id = messageId
+
+      // Set the author ID to our test user's ID
+      requestData.message!.author = { id: testUser.id }
+
+      // Make the request to process the message
+      await client.functions.invoke(FUNCTION_NAME, {
+        method: 'POST',
+        body: requestData,
+      })
+
+      // Find the inserted message
+      const [message] = await supabase
+        .select()
+        .from(twilioMessages)
+        .where(eq(twilioMessages.id, messageId))
+        .limit(1)
+
+      // Verify senderId is set to the author's ID
+      assertEquals(message.senderId, testUser.id)
+    })
+
+    it('sets senderId for outgoing Twilio messages', async () => {
+      const requestData = structuredClone(newOutgoingTwilioRequest)
+
+      // Generate a valid UUID for the message ID
+      const messageId = crypto.randomUUID()
+      requestData.message!.id = messageId
+
+      // Create a valid user first
+      const testUser = await createUser()
+
+      // Set the author ID to our test user's ID
+      requestData.message!.author = { id: testUser.id }
+
+      // Make the request to process the message
+      await client.functions.invoke(FUNCTION_NAME, {
+        method: 'POST',
+        body: requestData,
+      })
+
+      // Find the inserted message
+      const [message] = await supabase
+        .select()
+        .from(twilioMessages)
+        .where(eq(twilioMessages.id, messageId))
+        .limit(1)
+
+      // Verify senderId is set to the author's ID
+      assertEquals(message.senderId, testUser.id)
     })
   },
 )

--- a/supabase/functions/user-actions/handlers/twilio-message-handler.ts
+++ b/supabase/functions/user-actions/handlers/twilio-message-handler.ts
@@ -2,7 +2,7 @@ import { PostgresJsTransaction } from 'drizzle-orm/postgres-js'
 import { eq } from 'drizzle-orm'
 
 import { authors, ConversationAuthor, conversationsAuthors, twilioMessages } from '../../_shared/drizzle/schema.ts'
-import { RequestBody } from '../types.ts'
+import { RequestBody, RuleType } from '../types.ts'
 import { upsertAuthor, upsertConversation, upsertLabel, upsertRule } from './utils.ts'
 import { adaptTwilioMessage, adaptTwilioRequestAuthor } from '../adapters.ts'
 import Missive from '../../_shared/lib/Missive.ts'
@@ -56,7 +56,9 @@ const insertTwilioMessage = async (
     requestMessage.from_field.username ? requestMessage.from_field.username : requestMessage.from_field.id,
     requestMessage.to_fields[0].username ? requestMessage.to_fields[0].username : requestMessage.to_fields[0].id,
   )
-  twilioMessage.senderId = requestBody.rule.type === 'outgoing_twilio_message' ? requestMessage.author?.id : undefined
+  const isOutgoing = requestBody.rule.type === RuleType.OutgoingTwilioMessage ||
+    requestBody.rule.type === RuleType.OutgoingSmsMessage
+  twilioMessage.senderId = isOutgoing ? requestMessage.author?.id : undefined
   await tx.insert(twilioMessages).values(twilioMessage)
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Handle outgoing SMS and Twilio messages by setting senderId based on message type and add tests for verification.
> 
>   - **Behavior**:
>     - `insertTwilioMessage` in `twilio-message-handler.ts` now sets `senderId` for `RuleType.OutgoingTwilioMessage` and `RuleType.OutgoingSmsMessage`.
>     - Adds `newOutgoingSmsRequest` and `newOutgoingTwilioRequest` in `outgoing-twilio-message-request.ts` for testing.
>   - **Tests**:
>     - Adds tests in `twilio-message-handler-tests.ts` to verify `senderId` assignment for outgoing messages.
>     - Adds `createUser` function in `user.ts` for creating test users.
>   - **Misc**:
>     - Imports `RuleType` in `twilio-message-handler.ts` to handle rule type checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PublicDataWorks%2Ftxt-outlier-backend&utm_source=github&utm_medium=referral)<sup> for a5e73a4613c8d84ab8bfd117dae39e39967d11e3. You can [customize](https://app.ellipsis.dev/PublicDataWorks/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new test cases to verify correct assignment of the sender ID for incoming, outgoing SMS, and outgoing Twilio messages.
  - Introduced utility functions and fixtures to streamline user and message creation in tests.

- **Bug Fixes**
  - Improved logic to ensure the sender ID is set for both outgoing SMS and outgoing Twilio messages.

- **Chores**
  - Enhanced test infrastructure with new user factory and structured sample message data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->