### PR TITLE
Fix broadcast/campaign ID assignment and add label support to conversations

### DIFF
--- a/supabase/functions/user-actions/handlers/broadcast-handlers.ts
+++ b/supabase/functions/user-actions/handlers/broadcast-handlers.ts
@@ -83,8 +83,8 @@ const handleBroadcastReply = async (requestBody: RequestBody) => {
         .update(twilioMessages)
         .set({
           isReply: true,
-          replyToBroadcast: sentMessage[0].broadcastId || sentMessage[0].campaignId,
-          replyToCampaign: sentMessage[0].broadcastId || sentMessage[0].campaignId,
+          replyToBroadcast: sentMessage[0].broadcastId,
+          replyToCampaign: sentMessage[0].campaignId,
         })
         .where(eq(twilioMessages.id, requestMessage.id))
 

--- a/supabase/functions/user-actions/handlers/conversation-handler.ts
+++ b/supabase/functions/user-actions/handlers/conversation-handler.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm'
 import { PostgresJsTransaction } from 'drizzle-orm/postgres-js'
 
-import { upsertConversation, upsertOrganization, upsertRule } from './utils.ts'
+import { upsertConversation, upsertLabel, upsertOrganization, upsertRule } from './utils.ts'
 import { RequestBody, RequestConversation, RuleType } from '../types.ts'
 import {
   ConversationAssignee,
@@ -68,6 +68,7 @@ export const handleConversationAssigneeChange = async (requestBody: RequestBody)
       requestBody.conversation,
       inserted[0].id,
     )
+    await upsertLabel(tx, requestBody)
   })
 }
 


### PR DESCRIPTION
- Separate broadcastId and campaignId assignments instead of using fallback logic
- Add upsertLabel call when handling conversation assignee changes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Separate broadcast/campaign ID assignments and add label support in conversation assignee changes.
> 
>   - **Behavior**:
>     - Separate `broadcastId` and `campaignId` assignments in `handleBroadcastReply()` in `broadcast-handlers.ts`.
>     - Add `upsertLabel` call in `handleConversationAssigneeChange()` in `conversation-handler.ts` to support label updates.
>   - **Functions**:
>     - Modify `handleBroadcastReply()` to directly assign `broadcastId` and `campaignId` without fallback logic.
>     - Update `handleConversationAssigneeChange()` to include label upsertion.
>   - **Imports**:
>     - Add `upsertLabel` to imports in `conversation-handler.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PublicDataWorks%2Ftxt-outlier-backend&utm_source=github&utm_medium=referral)<sup> for 02a92c61e7405f10416ada1a5474ba4a748d2a8d. You can [customize](https://app.ellipsis.dev/PublicDataWorks/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected assignment of reply identifiers to ensure replies are accurately linked to broadcasts and campaigns.

* **New Features**
  * Added label management during conversation assignee changes to enhance organization and tracking of conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->