### PR TITLE
feat: add real-time label exclusion check for campaign messages with comprehensive tests

### DIFF
--- a/supabase/functions/_shared/lib/Missive.ts
+++ b/supabase/functions/_shared/lib/Missive.ts
@@ -11,6 +11,7 @@ const MISSIVE_ORGANIZATION_ID = Deno.env.get('MISSIVE_ORGANIZATION_ID')!
 const MISSIVE_SECRET_BROADCAST_SECOND_MESSAGES = Deno.env.get('MISSIVE_SECRET_BROADCAST_SECOND_MESSAGES')!
 const MISSIVE_SECRET_BROADCAST_FIRST_MESSAGES = Deno.env.get('MISSIVE_SECRET_BROADCAST_FIRST_MESSAGES')!
 const MISSIVE_SECRET_NON_BROADCAST = Deno.env.get('MISSIVE_SECRET_NON_BROADCAST')!
+const MISSIVE_SECRET_CAMPAIGN_READ_CONVERSATION = Deno.env.get('MISSIVE_SECRET_CAMPAIGN_READ_CONVERSATION')!
 
 const sendMessage = async (message: string, toPhone: string, isSecond: boolean, sharedLabelIds?: string[]) => {
   const startTime = Date.now()
@@ -87,6 +88,15 @@ const getMissiveMessage = async (id: string) => {
     'Authorization': `Bearer ${MISSIVE_SECRET_NON_BROADCAST}`,
   }
   const url = `${GET_MESSAGE_URL}${id}`
+  return await fetch(url, { method: 'GET', headers: headers })
+}
+
+const getMissiveConversation = async (id: string) => {
+  const headers = {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${MISSIVE_SECRET_CAMPAIGN_READ_CONVERSATION}`,
+  }
+  const url = `https://public.missiveapp.com/v1/conversations/${id}`
   return await fetch(url, { method: 'GET', headers: headers })
 }
 
@@ -207,6 +217,7 @@ export default {
   createPost,
   verifySignature,
   getMissiveMessage,
+  getMissiveConversation,
   createLabel,
   findLabelByName,
   CREATE_MESSAGE_URL,

--- a/supabase/functions/_shared/types/queue.ts
+++ b/supabase/functions/_shared/types/queue.ts
@@ -1,0 +1,17 @@
+export interface QueuedMessageMetadata {
+  recipient_phone_number: string
+  first_message: string
+  second_message?: string
+  broadcast_id?: number
+  campaign_id?: number
+  segment_id?: number
+  delay?: number
+  label_ids?: string[]
+  campaign_segments?: {
+    included?: Array<{ id: string; since?: number }>
+    excluded?: Array<{ id: string; since?: number }>
+  }
+  conversation_id?: string
+  title?: string
+  created_at?: number
+}

--- a/supabase/functions/tests/_mock/missive.ts
+++ b/supabase/functions/tests/_mock/missive.ts
@@ -1,0 +1,18 @@
+import * as sinon from 'npm:sinon'
+
+class MockMissiveUtils {
+  sendMessage = sinon.stub()
+  createPost = sinon.stub()
+  verifySignature = sinon.stub()
+  getMissiveMessage = sinon.stub()
+  getMissiveConversation = sinon.stub()
+  createLabel = sinon.stub()
+  findLabelByName = sinon.stub()
+  CREATE_MESSAGE_URL = 'https://public.missiveapp.com/v1/drafts'
+}
+
+const mockMissiveInstance = new MockMissiveUtils()
+
+export default mockMissiveInstance
+
+export const missiveMock = mockMissiveInstance

--- a/supabase/functions/tests/broadcast-service-tests.ts
+++ b/supabase/functions/tests/broadcast-service-tests.ts
@@ -1,0 +1,723 @@
+import { afterEach, beforeEach, describe, it } from 'jsr:@std/testing/bdd'
+import { assert, assertEquals, assertExists } from 'jsr:@std/assert'
+import * as sinon from 'npm:sinon'
+import { sql } from 'drizzle-orm'
+
+import './setup.ts'
+import supabase from '../_shared/lib/supabase.ts'
+import { messageStatuses } from '../_shared/drizzle/schema.ts'
+import { sendBroadcastMessage, shouldSkipCampaignMessage } from '../_shared/services/BroadcastService.ts'
+import { pgmqRead, pgmqSend } from '../_shared/scheduledcron/queries.ts'
+import { FIRST_MESSAGES_QUEUE, SECOND_MESSAGES_QUEUE_NAME } from '../_shared/constants.ts'
+import { missiveMock } from './_mock/missive.ts'
+import * as Sentry from 'sentry/deno'
+import type { QueuedMessageMetadata } from '../_shared/types/queue.ts'
+
+const sandbox = sinon.createSandbox()
+
+describe('sendBroadcastMessage', { sanitizeOps: false, sanitizeResources: false }, () => {
+  beforeEach(async () => {
+    missiveMock.sendMessage.reset()
+    missiveMock.getMissiveConversation.reset()
+    sandbox.stub(console, 'log')
+    sandbox.stub(console, 'error')
+    sandbox.stub(Sentry, 'captureException')
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('successful message sending', () => {
+    it('should send first message successfully and delete from queue', async () => {
+      const messageMetadata = {
+        first_message: 'Hello, this is the first message',
+        recipient_phone_number: '+1234567890',
+        broadcast_id: 123,
+        segment_id: 456,
+        label_ids: ['label1', 'label2'],
+      }
+
+      await supabase.execute(pgmqSend(FIRST_MESSAGES_QUEUE, JSON.stringify(messageMetadata), 0))
+
+      const mockResponse = new Response(
+        JSON.stringify({
+          drafts: {
+            id: 'missive-message-id',
+            conversation: 'missive-conversation-id',
+          },
+        }),
+        { status: 200 },
+      )
+      mockResponse.ok = true
+      missiveMock.sendMessage.resolves(mockResponse)
+
+      await sendBroadcastMessage(false)
+
+      sinon.assert.calledOnce(missiveMock.sendMessage)
+      sinon.assert.calledWith(
+        missiveMock.sendMessage,
+        messageMetadata.first_message,
+        messageMetadata.recipient_phone_number,
+        false,
+        messageMetadata.label_ids,
+      )
+
+      const remainingMessages = await supabase.execute(
+        sql.raw(`SELECT * FROM pgmq.q_${FIRST_MESSAGES_QUEUE}`),
+      )
+      assertEquals(remainingMessages.length, 0, 'Message should be deleted from queue')
+
+      const statuses = await supabase.select().from(messageStatuses)
+      assertEquals(statuses.length, 1)
+      assertEquals(statuses[0].recipientPhoneNumber, messageMetadata.recipient_phone_number)
+      assertEquals(statuses[0].message, messageMetadata.first_message)
+      assertEquals(statuses[0].isSecond, false)
+      assertEquals(statuses[0].broadcastId, messageMetadata.broadcast_id)
+      assertEquals(statuses[0].missiveId, 'missive-message-id')
+      assertEquals(statuses[0].missiveConversationId, 'missive-conversation-id')
+      assertEquals(statuses[0].audienceSegmentId, messageMetadata.segment_id)
+    })
+
+    it('should send first message and queue second message with delay', async () => {
+      const messageMetadata = {
+        first_message: 'First message',
+        second_message: 'Second message',
+        recipient_phone_number: '+1234567890',
+        broadcast_id: 123,
+        campaign_id: 789,
+        segment_id: 456,
+        delay: 300,
+        label_ids: ['label1'],
+      }
+
+      await supabase.execute(pgmqSend(FIRST_MESSAGES_QUEUE, JSON.stringify(messageMetadata), 0))
+
+      const mockResponse = new Response(
+        JSON.stringify({
+          drafts: {
+            id: 'missive-message-id',
+            conversation: 'missive-conversation-id',
+          },
+        }),
+        { status: 200 },
+      )
+      mockResponse.ok = true
+      missiveMock.sendMessage.resolves(mockResponse)
+
+      await sendBroadcastMessage(false)
+      sinon.assert.calledOnce(missiveMock.sendMessage)
+
+      const firstQueueMessages = await supabase.execute(
+        sql.raw(`SELECT * FROM pgmq.q_${FIRST_MESSAGES_QUEUE}`),
+      )
+      assertEquals(firstQueueMessages.length, 0)
+
+      const secondQueueMessages = await supabase.execute(
+        sql.raw(`SELECT * FROM pgmq.q_${SECOND_MESSAGES_QUEUE_NAME}`),
+      )
+      assertEquals(secondQueueMessages.length, 1)
+      const queuedMessage = JSON.parse(secondQueueMessages[0].message)
+      assertEquals(queuedMessage.first_message, messageMetadata.first_message)
+      assertEquals(queuedMessage.second_message, messageMetadata.second_message)
+      assertEquals(queuedMessage.recipient_phone_number, messageMetadata.recipient_phone_number)
+
+      const statuses = await supabase.select().from(messageStatuses)
+      assertEquals(statuses.length, 1)
+      assertExists(statuses[0].secondMessageQueueId)
+      assertEquals(statuses[0].campaignId, messageMetadata.campaign_id)
+    })
+
+    it('should send second message successfully', async () => {
+      const messageMetadata = {
+        first_message: 'First message',
+        second_message: 'Second message',
+        recipient_phone_number: '+1234567890',
+        broadcast_id: 123,
+        segment_id: 456,
+      }
+
+      await supabase.execute(pgmqSend(SECOND_MESSAGES_QUEUE_NAME, JSON.stringify(messageMetadata), 0))
+
+      const mockResponse = new Response(
+        JSON.stringify({
+          drafts: {
+            id: 'missive-second-id',
+            conversation: 'missive-conv-id',
+          },
+        }),
+        { status: 200 },
+      )
+      mockResponse.ok = true
+      missiveMock.sendMessage.resolves(mockResponse)
+
+      await sendBroadcastMessage(true)
+
+      sinon.assert.calledOnce(missiveMock.sendMessage)
+      sinon.assert.calledWith(
+        missiveMock.sendMessage,
+        messageMetadata.second_message,
+        messageMetadata.recipient_phone_number,
+        true,
+        undefined,
+      )
+
+      const remainingMessages = await supabase.execute(
+        sql.raw(`SELECT * FROM pgmq.q_${SECOND_MESSAGES_QUEUE_NAME}`),
+      )
+      assertEquals(remainingMessages.length, 0)
+
+      const statuses = await supabase.select().from(messageStatuses)
+      assertEquals(statuses.length, 1)
+      assertEquals(statuses[0].message, messageMetadata.second_message)
+      assertEquals(statuses[0].isSecond, true)
+    })
+  })
+
+  describe('error handling', () => {
+    it('should not delete message on API failure (non-429)', async () => {
+      const messageMetadata = {
+        first_message: 'Test message',
+        recipient_phone_number: '+1234567890',
+        broadcast_id: 123,
+      }
+
+      await supabase.execute(pgmqSend(FIRST_MESSAGES_QUEUE, JSON.stringify(messageMetadata), 0))
+
+      const mockResponse = new Response(JSON.stringify({ error: 'Internal Server Error' }), { status: 500 })
+      mockResponse.ok = false
+      missiveMock.sendMessage.resolves(mockResponse)
+
+      await sendBroadcastMessage(false)
+
+      sinon.assert.calledOnce(missiveMock.sendMessage)
+      sinon.assert.calledOnce(Sentry.captureException as sinon.SinonStub)
+
+      const remainingMessages = await supabase.execute(
+        sql.raw(`SELECT * FROM pgmq.q_${FIRST_MESSAGES_QUEUE}`),
+      )
+      assertEquals(remainingMessages.length, 1)
+
+      const statuses = await supabase.select().from(messageStatuses)
+      assertEquals(statuses.length, 0)
+    })
+
+    it('should handle 429 rate limit without deleting message', async () => {
+      const messageMetadata = {
+        first_message: 'Test message',
+        recipient_phone_number: '+1234567890',
+        broadcast_id: 123,
+      }
+
+      await supabase.execute(pgmqSend(FIRST_MESSAGES_QUEUE, JSON.stringify(messageMetadata), 0))
+      await supabase.execute(pgmqRead(FIRST_MESSAGES_QUEUE, 0))
+      await supabase.execute(pgmqRead(FIRST_MESSAGES_QUEUE, 0))
+      await supabase.execute(pgmqRead(FIRST_MESSAGES_QUEUE, 0))
+
+      const mockResponse = new Response(JSON.stringify({ error: 'Rate limit exceeded' }), { status: 429 })
+      mockResponse.ok = false
+      missiveMock.sendMessage.resolves(mockResponse)
+
+      await sendBroadcastMessage(false)
+
+      sinon.assert.calledOnce(Sentry.captureException as sinon.SinonStub)
+
+      const remainingMessages = await supabase.execute(
+        sql.raw(`SELECT * FROM pgmq.q_${FIRST_MESSAGES_QUEUE}`),
+      )
+      assertEquals(remainingMessages.length, 1, 'Message should remain in queue for 429 errors')
+    })
+
+    it('should delete message after max retries for non-429 errors', async () => {
+      const messageMetadata = {
+        first_message: 'Test message',
+        recipient_phone_number: '+1234567890',
+        broadcast_id: 123,
+      }
+
+      await supabase.execute(pgmqSend(FIRST_MESSAGES_QUEUE, JSON.stringify(messageMetadata), 0))
+      await supabase.execute(pgmqRead(FIRST_MESSAGES_QUEUE, 0))
+      await supabase.execute(pgmqRead(FIRST_MESSAGES_QUEUE, 0))
+      await supabase.execute(pgmqRead(FIRST_MESSAGES_QUEUE, 0))
+
+      const mockResponse = new Response(JSON.stringify({ error: 'Server Error' }), { status: 500 })
+      mockResponse.ok = false
+      missiveMock.sendMessage.resolves(mockResponse)
+
+      await sendBroadcastMessage(false)
+
+      sinon.assert.calledTwice(Sentry.captureException as sinon.SinonStub)
+
+      const remainingMessages = await supabase.execute(
+        sql.raw(`SELECT * FROM pgmq.q_${FIRST_MESSAGES_QUEUE}`),
+      )
+      assertEquals(remainingMessages.length, 0, 'Message should be deleted after max retries')
+    })
+  })
+
+  describe('empty queue handling', () => {
+    it('should return early when queue is empty', async () => {
+      await sendBroadcastMessage(false)
+
+      sinon.assert.notCalled(missiveMock.sendMessage)
+      sinon.assert.notCalled(Sentry.captureException as sinon.SinonStub)
+
+      const statuses = await supabase.select().from(messageStatuses)
+      assertEquals(statuses.length, 0)
+    })
+  })
+
+  describe('campaign exclusion handling', () => {
+    it('should skip sending campaign message when recipient has excluded label', async () => {
+      const messageMetadata: QueuedMessageMetadata = {
+        recipient_phone_number: '+1234567890',
+        first_message: 'Campaign message',
+        campaign_id: 123,
+        campaign_segments: {
+          excluded: [{ id: 'exclude-label-1', since: 0 }],
+        },
+        conversation_id: 'conv-456',
+        label_ids: ['label1'],
+      }
+
+      await supabase.execute(pgmqSend(FIRST_MESSAGES_QUEUE, JSON.stringify(messageMetadata), 0))
+
+      const mockConversationResponse = new Response(
+        JSON.stringify({
+          conversations: {
+            shared_labels: [
+              { id: 'exclude-label-1', name: 'Excluded' },
+              { id: 'other-label', name: 'Other' },
+            ],
+          },
+        }),
+        { status: 200 },
+      )
+      mockConversationResponse.ok = true
+      missiveMock.getMissiveConversation.resolves(mockConversationResponse)
+
+      await sendBroadcastMessage(false)
+
+      sinon.assert.calledOnce(missiveMock.getMissiveConversation)
+      sinon.assert.calledWith(missiveMock.getMissiveConversation, 'conv-456')
+      sinon.assert.notCalled(missiveMock.sendMessage)
+
+      const remainingMessages = await supabase.execute(
+        sql.raw(`SELECT * FROM pgmq.q_${FIRST_MESSAGES_QUEUE}`),
+      )
+      assertEquals(remainingMessages.length, 0, 'Message should be deleted from queue')
+
+      const statuses = await supabase.select().from(messageStatuses)
+      assertEquals(statuses.length, 0, 'No message status should be created for skipped messages')
+    })
+
+    it('should send campaign message when recipient has no excluded labels', async () => {
+      const messageMetadata: QueuedMessageMetadata = {
+        recipient_phone_number: '+1234567890',
+        first_message: 'Campaign message',
+        campaign_id: 123,
+        campaign_segments: {
+          excluded: [{ id: 'exclude-label-1', since: 0 }],
+        },
+        conversation_id: 'conv-456',
+        label_ids: ['label1'],
+      }
+
+      await supabase.execute(pgmqSend(FIRST_MESSAGES_QUEUE, JSON.stringify(messageMetadata), 0))
+
+      const mockConversationResponse = new Response(
+        JSON.stringify({
+          conversations: {
+            shared_labels: [
+              { id: 'different-label', name: 'Different' },
+              { id: 'other-label', name: 'Other' },
+            ],
+          },
+        }),
+        { status: 200 },
+      )
+      mockConversationResponse.ok = true
+      missiveMock.getMissiveConversation.resolves(mockConversationResponse)
+
+      const mockSendResponse = new Response(
+        JSON.stringify({
+          drafts: {
+            id: 'msg-id',
+            conversation: 'conv-id',
+          },
+        }),
+        { status: 200 },
+      )
+      mockSendResponse.ok = true
+      missiveMock.sendMessage.resolves(mockSendResponse)
+
+      await sendBroadcastMessage(false)
+
+      sinon.assert.calledOnce(missiveMock.getMissiveConversation)
+      sinon.assert.calledOnce(missiveMock.sendMessage)
+      sinon.assert.calledWith(
+        missiveMock.sendMessage,
+        messageMetadata.first_message,
+        messageMetadata.recipient_phone_number,
+        false,
+        messageMetadata.label_ids,
+      )
+
+      const statuses = await supabase.select().from(messageStatuses)
+      assertEquals(statuses.length, 1)
+      assertEquals(statuses[0].campaignId, 123)
+    })
+
+    it('should send campaign message when Missive conversation API fails', async () => {
+      const messageMetadata: QueuedMessageMetadata = {
+        recipient_phone_number: '+1234567890',
+        first_message: 'Campaign message',
+        campaign_id: 123,
+        campaign_segments: {
+          excluded: [{ id: 'exclude-label-1', since: 0 }],
+        },
+        conversation_id: 'conv-456',
+        label_ids: ['label1'],
+      }
+
+      await supabase.execute(pgmqSend(FIRST_MESSAGES_QUEUE, JSON.stringify(messageMetadata), 0))
+
+      const mockConversationResponse = new Response(JSON.stringify({ error: 'Not found' }), { status: 404 })
+      mockConversationResponse.ok = false
+      missiveMock.getMissiveConversation.resolves(mockConversationResponse)
+
+      const mockSendResponse = new Response(
+        JSON.stringify({
+          drafts: {
+            id: 'msg-id',
+            conversation: 'conv-id',
+          },
+        }),
+        { status: 200 },
+      )
+      mockSendResponse.ok = true
+      missiveMock.sendMessage.resolves(mockSendResponse)
+
+      await sendBroadcastMessage(false)
+
+      sinon.assert.calledOnce(missiveMock.getMissiveConversation)
+      sinon.assert.calledOnce(missiveMock.sendMessage)
+
+      const statuses = await supabase.select().from(messageStatuses)
+      assertEquals(statuses.length, 1)
+      assertEquals(statuses[0].campaignId, 123)
+    })
+
+    it('should skip campaign message for second message with exclusion', async () => {
+      const messageMetadata: QueuedMessageMetadata = {
+        recipient_phone_number: '+1234567890',
+        first_message: 'First',
+        second_message: 'Second campaign message',
+        campaign_id: 123,
+        campaign_segments: {
+          excluded: [{ id: 'exclude-label-1', since: 0 }],
+        },
+        conversation_id: 'conv-456',
+      }
+
+      await supabase.execute(pgmqSend(SECOND_MESSAGES_QUEUE_NAME, JSON.stringify(messageMetadata), 0))
+
+      const mockConversationResponse = new Response(
+        JSON.stringify({
+          conversations: {
+            shared_labels: [
+              { id: 'exclude-label-1', name: 'Excluded' },
+            ],
+          },
+        }),
+        { status: 200 },
+      )
+      mockConversationResponse.ok = true
+      missiveMock.getMissiveConversation.resolves(mockConversationResponse)
+
+      await sendBroadcastMessage(true)
+
+      sinon.assert.calledOnce(missiveMock.getMissiveConversation)
+      sinon.assert.notCalled(missiveMock.sendMessage)
+
+      const remainingMessages = await supabase.execute(
+        sql.raw(`SELECT * FROM pgmq.q_${SECOND_MESSAGES_QUEUE_NAME}`),
+      )
+      assertEquals(remainingMessages.length, 0, 'Message should be deleted from queue')
+    })
+  })
+})
+
+describe('shouldSkipCampaignMessage', { sanitizeOps: false, sanitizeResources: false }, () => {
+  beforeEach(() => {
+    missiveMock.getMissiveConversation.reset()
+    sandbox.stub(console, 'error')
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it('should return false when not a campaign message', async () => {
+    const messageMetadata: QueuedMessageMetadata = {
+      recipient_phone_number: '+1234567890',
+      first_message: 'Test message',
+      broadcast_id: 123,
+    }
+
+    const shouldSkip = await shouldSkipCampaignMessage(messageMetadata)
+    assertEquals(shouldSkip, false)
+    sinon.assert.notCalled(missiveMock.getMissiveConversation)
+  })
+
+  it('should return false when campaign has no excluded segments', async () => {
+    const messageMetadata: QueuedMessageMetadata = {
+      recipient_phone_number: '+1234567890',
+      first_message: 'Test message',
+      campaign_id: 123,
+      campaign_segments: {
+        included: [{ id: 'inc-1', since: 0 }],
+      },
+      conversation_id: 'conv-123',
+    }
+
+    const shouldSkip = await shouldSkipCampaignMessage(messageMetadata)
+    assertEquals(shouldSkip, false)
+    sinon.assert.notCalled(missiveMock.getMissiveConversation)
+  })
+
+  it('should return false when no conversation_id', async () => {
+    const messageMetadata: QueuedMessageMetadata = {
+      recipient_phone_number: '+1234567890',
+      first_message: 'Test message',
+      campaign_id: 123,
+      campaign_segments: {
+        excluded: [{ id: 'exc-1', since: 0 }],
+      },
+    }
+
+    const shouldSkip = await shouldSkipCampaignMessage(messageMetadata)
+    assertEquals(shouldSkip, false)
+    sinon.assert.notCalled(missiveMock.getMissiveConversation)
+  })
+
+  it('should return true when conversation has excluded label', async () => {
+    const messageMetadata: QueuedMessageMetadata = {
+      recipient_phone_number: '+1234567890',
+      first_message: 'Test message',
+      campaign_id: 123,
+      campaign_segments: {
+        excluded: [
+          { id: 'label-1', since: 0 },
+          { id: 'label-2', since: 0 },
+        ],
+      },
+      conversation_id: 'conv-123',
+    }
+
+    const mockResponse = new Response(
+      JSON.stringify({
+        conversations: {
+          shared_labels: [
+            { id: 'label-2', name: 'Excluded Label' },
+            { id: 'label-3', name: 'Other Label' },
+          ],
+        },
+      }),
+      { status: 200 },
+    )
+    mockResponse.ok = true
+    missiveMock.getMissiveConversation.resolves(mockResponse)
+
+    const shouldSkip = await shouldSkipCampaignMessage(messageMetadata)
+    assertEquals(shouldSkip, true)
+    sinon.assert.calledOnce(missiveMock.getMissiveConversation)
+    sinon.assert.calledWith(missiveMock.getMissiveConversation, 'conv-123')
+  })
+
+  it('should return false when conversation has no excluded labels', async () => {
+    const messageMetadata: QueuedMessageMetadata = {
+      recipient_phone_number: '+1234567890',
+      first_message: 'Test message',
+      campaign_id: 123,
+      campaign_segments: {
+        excluded: [
+          { id: 'label-1', since: 0 },
+          { id: 'label-2', since: 0 },
+        ],
+      },
+      conversation_id: 'conv-123',
+    }
+
+    const mockResponse = new Response(
+      JSON.stringify({
+        conversations: {
+          shared_labels: [
+            { id: 'label-3', name: 'Different Label' },
+            { id: 'label-4', name: 'Another Label' },
+          ],
+        },
+      }),
+      { status: 200 },
+    )
+    mockResponse.ok = true
+    missiveMock.getMissiveConversation.resolves(mockResponse)
+
+    const shouldSkip = await shouldSkipCampaignMessage(messageMetadata)
+    assertEquals(shouldSkip, false)
+    sinon.assert.calledOnce(missiveMock.getMissiveConversation)
+  })
+
+  it('should return false when Missive API call fails', async () => {
+    const messageMetadata: QueuedMessageMetadata = {
+      recipient_phone_number: '+1234567890',
+      first_message: 'Test message',
+      campaign_id: 123,
+      campaign_segments: {
+        excluded: [{ id: 'label-1', since: 0 }],
+      },
+      conversation_id: 'conv-123',
+    }
+
+    const mockResponse = new Response(JSON.stringify({ error: 'Not found' }), { status: 404 })
+    mockResponse.ok = false
+    missiveMock.getMissiveConversation.resolves(mockResponse)
+
+    const shouldSkip = await shouldSkipCampaignMessage(messageMetadata)
+    assertEquals(shouldSkip, false)
+    sinon.assert.calledOnce(missiveMock.getMissiveConversation)
+  })
+
+  it('should return false and log error when exception occurs', async () => {
+    const messageMetadata: QueuedMessageMetadata = {
+      recipient_phone_number: '+1234567890',
+      first_message: 'Test message',
+      campaign_id: 123,
+      campaign_segments: {
+        excluded: [{ id: 'label-1', since: 0 }],
+      },
+      conversation_id: 'conv-123',
+    }
+
+    missiveMock.getMissiveConversation.rejects(new Error('Network error'))
+
+    const shouldSkip = await shouldSkipCampaignMessage(messageMetadata)
+    assertEquals(shouldSkip, false)
+    sinon.assert.calledOnce(missiveMock.getMissiveConversation)
+    sinon.assert.calledOnce(console.error as sinon.SinonStub)
+  })
+})
+
+describe('sendBroadcastMessage with campaign exclusion', { sanitizeOps: false, sanitizeResources: false }, () => {
+  beforeEach(() => {
+    missiveMock.sendMessage.reset()
+    missiveMock.getMissiveConversation.reset()
+    sandbox.stub(console, 'log')
+    sandbox.stub(console, 'error')
+    sandbox.stub(Sentry, 'captureException')
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it('should skip sending when recipient has excluded label', async () => {
+    const messageMetadata: QueuedMessageMetadata = {
+      recipient_phone_number: '+1234567890',
+      first_message: 'Campaign message',
+      campaign_id: 123,
+      campaign_segments: {
+        excluded: [{ id: 'exclude-label-1', since: 0 }],
+      },
+      conversation_id: 'conv-456',
+      label_ids: ['label1'],
+    }
+
+    await supabase.execute(pgmqSend(FIRST_MESSAGES_QUEUE, JSON.stringify(messageMetadata), 0))
+
+    const mockConversationResponse = new Response(
+      JSON.stringify({
+        conversations: {
+          shared_labels: [
+            { id: 'exclude-label-1', name: 'Excluded' },
+            { id: 'other-label', name: 'Other' },
+          ],
+        },
+      }),
+      { status: 200 },
+    )
+    mockConversationResponse.ok = true
+    missiveMock.getMissiveConversation.resolves(mockConversationResponse)
+
+    await sendBroadcastMessage(false)
+
+    sinon.assert.calledOnce(missiveMock.getMissiveConversation)
+    sinon.assert.calledWith(missiveMock.getMissiveConversation, 'conv-456')
+    sinon.assert.notCalled(missiveMock.sendMessage)
+
+    const remainingMessages = await supabase.execute(
+      sql.raw(`SELECT * FROM pgmq.q_${FIRST_MESSAGES_QUEUE}`),
+    )
+    assertEquals(remainingMessages.length, 0, 'Message should be deleted from queue')
+
+    const statuses = await supabase.select().from(messageStatuses)
+    assertEquals(statuses.length, 0, 'No message status should be created for skipped messages')
+  })
+
+  it('should send message when recipient has no excluded labels', async () => {
+    const messageMetadata: QueuedMessageMetadata = {
+      recipient_phone_number: '+1234567890',
+      first_message: 'Campaign message',
+      campaign_id: 123,
+      campaign_segments: {
+        excluded: [{ id: 'exclude-label-1', since: 0 }],
+      },
+      conversation_id: 'conv-456',
+      label_ids: ['label1'],
+    }
+
+    await supabase.execute(pgmqSend(FIRST_MESSAGES_QUEUE, JSON.stringify(messageMetadata), 0))
+
+    const mockConversationResponse = new Response(
+      JSON.stringify({
+        conversations: {
+          shared_labels: [
+            { id: 'different-label', name: 'Different' },
+            { id: 'other-label', name: 'Other' },
+          ],
+        },
+      }),
+      { status: 200 },
+    )
+    mockConversationResponse.ok = true
+    missiveMock.getMissiveConversation.resolves(mockConversationResponse)
+
+    const mockSendResponse = new Response(
+      JSON.stringify({
+        drafts: {
+          id: 'msg-id',
+          conversation: 'conv-id',
+        },
+      }),
+      { status: 200 },
+    )
+    mockSendResponse.ok = true
+    missiveMock.sendMessage.resolves(mockSendResponse)
+
+    await sendBroadcastMessage(false)
+
+    sinon.assert.calledOnce(missiveMock.getMissiveConversation)
+    sinon.assert.calledOnce(missiveMock.sendMessage)
+    sinon.assert.calledWith(
+      missiveMock.sendMessage,
+      messageMetadata.first_message,
+      messageMetadata.recipient_phone_number,
+      false,
+      messageMetadata.label_ids,
+    )
+
+    const statuses = await supabase.select().from(messageStatuses)
+    assertEquals(statuses.length, 1)
+    assertEquals(statuses[0].campaignId, 123)
+  })
+})

--- a/supabase/functions/tests/deno.json
+++ b/supabase/functions/tests/deno.json
@@ -29,8 +29,7 @@
     "base64": "https://denopkg.com/chiefbiiko/base64/mod.ts",
     "supabase-js": "https://esm.sh/@supabase/supabase-js@2",
     "jsonwebtoken": "npm:jsonwebtoken",
-    "sentry/deno": "https://deno.land/x/sentry@7.114.0/index.mjs",
-    "sentry/node": "npm:@sentry/node@^7.114.0",
+    "sentry": "https://deno.land/x/sentry@8.53.0/index.mjs",
     "dub": "./_mock/dub.ts",
     "../_shared/lib/Missive.ts": "./_mock/missive.ts"
   }

--- a/supabase/functions/tests/deno.json
+++ b/supabase/functions/tests/deno.json
@@ -31,6 +31,7 @@
     "jsonwebtoken": "npm:jsonwebtoken",
     "sentry/deno": "https://deno.land/x/sentry@7.114.0/index.mjs",
     "sentry/node": "npm:@sentry/node@^7.114.0",
-    "dub": "./_mock/dub.ts"
+    "dub": "./_mock/dub.ts",
+    "../_shared/lib/Missive.ts": "./_mock/missive.ts"
   }
 }

--- a/supabase/migrations/20250310074006_add_file_based_campaigns.sql
+++ b/supabase/migrations/20250310074006_add_file_based_campaigns.sql
@@ -342,16 +342,19 @@ BEGIN
             'broadcast_first_messages',
             ARRAY(
                 SELECT jsonb_build_object(
-                    'recipient_phone_number', phone_number,
+                    'recipient_phone_number', crt.phone_number,
                     'campaign_id', p_campaign_id,
                     'first_message', v_campaign_record.first_message,
                     'second_message', v_campaign_record.second_message,
                     'title', v_campaign_record.title,
                     'delay', v_campaign_record.delay,
                     'label_ids', v_campaign_record.label_ids,
+                    'campaign_segments', v_campaign_record.segments,
+                    'conversation_id', ca.conversation_id::TEXT,
                     'created_at', EXTRACT(EPOCH FROM NOW())::INTEGER
                 )
-                FROM campaign_recipients_temp
+                FROM campaign_recipients_temp crt
+                LEFT JOIN conversations_authors ca ON crt.phone_number = ca.author_phone_number
                 LIMIT v_batch_size
                 OFFSET v_offset * v_batch_size
             )


### PR DESCRIPTION
Implements real-time label exclusion checking for campaign messages to prevent sending messages to recipients
who have been added to excluded segments after the campaign was queued.

Changes

- Added shouldSkipCampaignMessage logic in BroadcastService to check recipient labels against campaign
exclusion segments before sending
- Added getMissiveConversation API method to fetch conversation labels
- Extended QueuedMessageMetadata type to include campaign segments and conversation ID
- Added comprehensive test coverage for broadcast and campaign message sending including:
- Successful message sending and queueing
- Campaign exclusion handling
- Error handling for API failures and rate limits
- Second message queue behavior