### PR TITLE
Count unique senders in campaign reply statistics

### DIFF
--- a/supabase/functions/_shared/scheduledcron/queries.ts
+++ b/supabase/functions/_shared/scheduledcron/queries.ts
@@ -161,7 +161,7 @@ function getPastCampaignsWithStatsQuery(page: number, pageSize: number) {
     replies AS (
       SELECT
         reply_to_campaign AS campaign_id,
-        COUNT(*) AS total_replies
+        COUNT(DISTINCT from_field) AS total_replies
       FROM twilio_messages
       WHERE reply_to_campaign IS NOT NULL
         AND reply_to_campaign IN (SELECT id FROM past_campaigns)

--- a/supabase/functions/tests/campaigns-tests.ts
+++ b/supabase/functions/tests/campaigns-tests.ts
@@ -1230,15 +1230,19 @@ describe('GET', { sanitizeOps: false, sanitizeResources: false }, () => {
       processed: true,
     })
 
-    const fromPhone = '+12345678901'
+    const fromPhone1 = '+12345678901'
+    const fromPhone2 = '+12345678902'
+    const fromPhone3 = '+12345678903'
     const toPhone = '+19876543210'
 
-    await createAuthor(fromPhone, { unsubscribed: false, exclude: false })
+    await createAuthor(fromPhone1, { unsubscribed: false, exclude: false })
+    await createAuthor(fromPhone2, { unsubscribed: false, exclude: false })
+    await createAuthor(fromPhone3, { unsubscribed: false, exclude: false })
     await createAuthor(toPhone, { unsubscribed: false, exclude: false })
 
     await createTwilioMessage({
       preview: 'Reply 1',
-      fromField: fromPhone,
+      fromField: fromPhone1,
       toField: toPhone,
       isReply: true,
       replyToCampaign: pastCampaign.id,
@@ -1246,7 +1250,7 @@ describe('GET', { sanitizeOps: false, sanitizeResources: false }, () => {
 
     await createTwilioMessage({
       preview: 'Reply 2',
-      fromField: fromPhone,
+      fromField: fromPhone2,
       toField: toPhone,
       isReply: true,
       replyToCampaign: pastCampaign.id,
@@ -1254,7 +1258,7 @@ describe('GET', { sanitizeOps: false, sanitizeResources: false }, () => {
 
     await createTwilioMessage({
       preview: 'Reply 3',
-      fromField: fromPhone,
+      fromField: fromPhone2,
       toField: toPhone,
       isReply: true,
       replyToCampaign: pastCampaign.id,
@@ -1268,7 +1272,7 @@ describe('GET', { sanitizeOps: false, sanitizeResources: false }, () => {
     const testCampaign = data.past.items.find((c) => c.id === pastCampaign.id)
 
     assertEquals(testCampaign !== undefined, true)
-    assertEquals(testCampaign.totalReplies, 3)
+    assertEquals(testCampaign.totalReplies, 2)
   })
 })
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update campaign reply statistics to count unique senders and adjust tests accordingly.
> 
>   - **Behavior**:
>     - Update `getPastCampaignsWithStatsQuery` in `queries.ts` to count unique senders using `COUNT(DISTINCT from_field)` for `total_replies`.
>   - **Tests**:
>     - Modify test in `campaigns-tests.ts` to use multiple `fromPhone` values and verify `totalReplies` is 2 instead of 3.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PublicDataWorks%2Ftxt-outlier-backend&utm_source=github&utm_medium=referral)<sup> for 2f3ad0673007aff41c135a47cad436fb6bf6ae95. You can [customize](https://app.ellipsis.dev/PublicDataWorks/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Past Campaigns and related reports now count totalReplies as unique contacts who replied, rather than total reply messages. This provides more accurate engagement metrics and deduplicates multiple replies from the same contact. You may notice reduced totals where contacts sent multiple messages in a campaign.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->