### PR TITLE
fix: move organization and rule upserts outside transaction to prevent deadlock

### DIFF
--- a/supabase/functions/tests/user-action-tests/new-comment-tests.ts
+++ b/supabase/functions/tests/user-action-tests/new-comment-tests.ts
@@ -181,6 +181,35 @@ describe(
       })
     })
 
+    it('should update user name and email on subsequent comments', async () => {
+      const body1 = JSON.parse(JSON.stringify(newCommentRequest))
+      body1.conversation.users = []
+      await client.functions.invoke(FUNCTION_NAME, {
+        method: 'POST',
+        body: body1,
+      })
+
+      const usersBefore = await supabase.select().from(users)
+      assertEquals(usersBefore.length, 1)
+      assertEquals(usersBefore[0].name, 'User 3')
+      assertEquals(usersBefore[0].email, 'user3@mail.com')
+
+      const body2 = JSON.parse(JSON.stringify(newCommentRequest))
+      body2.comment!.id = 'deadfeed-dead-feed-dead-deadfeed0003'
+      body2.comment!.author.name = 'User 3 Updated'
+      body2.comment!.author.email = 'user3updated@mail.com'
+      body2.conversation.users = []
+      await client.functions.invoke(FUNCTION_NAME, {
+        method: 'POST',
+        body: body2,
+      })
+
+      const usersAfter = await supabase.select().from(users)
+      assertEquals(usersAfter.length, 1)
+      assertEquals(usersAfter[0].name, 'User 3 Updated')
+      assertEquals(usersAfter[0].email, 'user3updated@mail.com')
+    })
+
     it('missing organization does not crash the server', async () => {
       const body = JSON.parse(JSON.stringify(newCommentRequest))
       body.comment!.id = 'deadfeed-dead-feed-dead-deadfeed0002'

--- a/supabase/functions/user-actions/handlers/comment-handler.ts
+++ b/supabase/functions/user-actions/handlers/comment-handler.ts
@@ -2,7 +2,7 @@ import { PostgresJsTransaction } from 'drizzle-orm/postgres-js'
 import { sql } from 'drizzle-orm'
 
 import { MentionTeam, MentionUser, RequestBody, RequestTask } from '../types.ts'
-import { ensureRuleExists, upsertConversation, upsertUsers } from './utils.ts'
+import { upsertConversation, upsertUsers } from './utils.ts'
 import {
   Comment,
   CommentMention,
@@ -15,7 +15,6 @@ import {
 import supabase from '../../_shared/lib/supabase.ts'
 
 export const handleNewComment = async (requestBody: RequestBody) => {
-  await ensureRuleExists(requestBody.rule)
   await supabase.transaction(async (tx) => {
     const users = [
       requestBody.comment!.author,

--- a/supabase/functions/user-actions/handlers/conversation-handler.ts
+++ b/supabase/functions/user-actions/handlers/conversation-handler.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm'
 import { PostgresJsTransaction } from 'drizzle-orm/postgres-js'
 
-import { ensureRuleExists, upsertConversation, upsertLabel, upsertOrganization } from './utils.ts'
+import { upsertConversation, upsertLabel } from './utils.ts'
 import { RequestBody, RequestConversation, RuleType } from '../types.ts'
 import {
   ConversationAssignee,
@@ -15,11 +15,8 @@ import { adaptConversationAssignee, adaptConversationAssigneeHistory } from '../
 import supabase from '../../_shared/lib/supabase.ts'
 
 export const handleConversationStatusChanged = async (requestBody: RequestBody, changeType: string) => {
-  await ensureRuleExists(requestBody.rule)
   await supabase.transaction(async (tx) => {
     const teamId = requestBody.conversation.team ? requestBody.conversation.team!.id : null
-
-    await upsertOrganization(tx, requestBody.conversation.organization)
 
     if (requestBody.conversation.team) {
       const teamData = {
@@ -40,7 +37,6 @@ export const handleConversationStatusChanged = async (requestBody: RequestBody, 
       requestBody.conversation,
       changeType === RuleType.ConversationClosed,
       false,
-      true,
       teamId,
     )
 
@@ -54,7 +50,6 @@ export const handleConversationStatusChanged = async (requestBody: RequestBody, 
 }
 
 export const handleConversationAssigneeChange = async (requestBody: RequestBody) => {
-  await ensureRuleExists(requestBody.rule)
   await supabase.transaction(async (tx) => {
     await upsertConversation(tx, requestBody.conversation)
     const convoHistory = {

--- a/supabase/functions/user-actions/handlers/label-handler.ts
+++ b/supabase/functions/user-actions/handlers/label-handler.ts
@@ -1,9 +1,8 @@
-import { ensureRuleExists, upsertConversation, upsertLabel } from './utils.ts'
+import { upsertConversation, upsertLabel } from './utils.ts'
 import { RequestBody } from '../types.ts'
 import supabase from '../../_shared/lib/supabase.ts'
 
 export const handleLabelChange = async (requestBody: RequestBody) => {
-  await ensureRuleExists(requestBody.rule)
   await supabase.transaction(async (tx) => {
     await upsertConversation(tx, requestBody.conversation)
     await upsertLabel(tx, requestBody)

--- a/supabase/functions/user-actions/handlers/team-handler.ts
+++ b/supabase/functions/user-actions/handlers/team-handler.ts
@@ -1,12 +1,10 @@
 import { conversationHistory, teams } from '../../_shared/drizzle/schema.ts'
 import supabase from '../../_shared/lib/supabase.ts'
-import { ensureRuleExists, upsertConversation, upsertOrganization } from './utils.ts'
+import { upsertConversation } from './utils.ts'
 import { RequestBody, RuleType } from '../types.ts'
 
 export const handleTeamChange = async (requestBody: RequestBody) => {
-  await ensureRuleExists(requestBody.rule)
   await supabase.transaction(async (tx) => {
-    await upsertOrganization(tx, requestBody.conversation.organization)
     if (requestBody.conversation.team) {
       const teamData = {
         id: requestBody.conversation.team.id,
@@ -23,7 +21,6 @@ export const handleTeamChange = async (requestBody: RequestBody) => {
       tx,
       requestBody.conversation,
       null,
-      false,
       false,
       teamId,
     )

--- a/supabase/functions/user-actions/handlers/twilio-message-handler.ts
+++ b/supabase/functions/user-actions/handlers/twilio-message-handler.ts
@@ -3,7 +3,7 @@ import { eq } from 'drizzle-orm'
 
 import { authors, ConversationAuthor, conversationsAuthors, twilioMessages } from '../../_shared/drizzle/schema.ts'
 import { RequestBody, RuleType } from '../types.ts'
-import { ensureRuleExists, upsertAuthor, upsertConversation, upsertLabel } from './utils.ts'
+import { upsertAuthor, upsertConversation, upsertLabel } from './utils.ts'
 import { adaptTwilioMessage, adaptTwilioRequestAuthor } from '../adapters.ts'
 import Missive from '../../_shared/lib/Missive.ts'
 import supabase from '../../_shared/lib/supabase.ts'
@@ -11,7 +11,6 @@ import supabase from '../../_shared/lib/supabase.ts'
 const RESUBSCRIBED_TERMS = ['start', 'resubscribe', 'detroit']
 
 const handleTwilioMessage = async (requestBody: RequestBody) => {
-  await ensureRuleExists(requestBody.rule)
   await supabase.transaction(async (tx) => {
     await upsertConversation(tx, requestBody.conversation)
     await insertTwilioMessage(tx, requestBody)

--- a/supabase/functions/user-actions/handlers/utils.ts
+++ b/supabase/functions/user-actions/handlers/utils.ts
@@ -85,7 +85,7 @@ export const upsertUsers = async (
     }
   }
   await tx.insert(users).values(newUsers).onConflictDoUpdate({
-    target: rules.id,
+    target: users.id,
     set: {
       name: sql`excluded.name`,
       email: sql`excluded.email`,

--- a/supabase/functions/user-actions/index.ts
+++ b/supabase/functions/user-actions/index.ts
@@ -1,5 +1,5 @@
 import { RuleType } from './types.ts'
-import { handleError, insertHistory } from './handlers/utils.ts'
+import { ensureOrganizationExists, ensureRuleExists, handleError, insertHistory } from './handlers/utils.ts'
 import { handleNewComment } from './handlers/comment-handler.ts'
 import { handleTeamChange } from './handlers/team-handler.ts'
 import { handleLabelChange } from './handlers/label-handler.ts'
@@ -30,6 +30,10 @@ Deno.serve(async (req: Request) => {
       `Start handling rule: ${requestBody.rule.id}, ${requestBody.rule.type}, ${requestBody.conversation?.id}`,
     )
     await insertHistory(requestBody)
+    await ensureRuleExists(requestBody.rule)
+    if (requestBody.conversation?.organization) {
+      await ensureOrganizationExists(requestBody.conversation.organization)
+    }
     switch (requestBody.rule.type) {
       case RuleType.NewComment:
         await handleNewComment(requestBody)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Move organization and rule upserts outside transactions to prevent deadlocks and add tests for missing organization and concurrent webhooks.
> 
>   - **Behavior**:
>     - Move `ensureRuleExists` and `ensureOrganizationExists` outside transactions in `index.ts` to prevent deadlocks.
>     - Remove `ensureRuleExists` and `upsertOrganization` from transactions in `comment-handler.ts`, `conversation-handler.ts`, `label-handler.ts`, `team-handler.ts`, and `twilio-message-handler.ts`.
>   - **Tests**:
>     - Add test for missing organization scenario in `new-comment-tests.ts`.
>     - Add test for concurrent comment and conversation webhooks in `new-comment-tests.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PublicDataWorks%2Ftxt-outlier-backend&utm_source=github&utm_medium=referral)<sup> for 37e4dd94c12f106f8d0a43ddd4339f0b96a04373. You can [customize](https://app.ellipsis.dev/PublicDataWorks/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented server crash when organization data is missing.
  * Resolved deadlock when comment and conversation webhooks arrive concurrently.
  * Ensure subsequent comments correctly update user name and email.

* **Reliability**
  * Added checks to confirm related entities exist before processing to reduce failures.

* **Tests**
  * Added tests covering missing-organization, concurrent-webhook, and subsequent-comment user-update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->