### PR TITLE
fix: disable verify_jwt on user-actions webhook + harden rejection path

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -259,6 +259,13 @@ inspector_port = 8083
 # For example, if you want to serve static HTML pages in your function:
 # static_files = [ "./functions/MY_FUNCTION_NAME/*.html" ]
 
+# Public Missive webhook receiver. It authenticates requests itself via the
+# Missive HMAC signature (x-hook-signature) in Missive.verifySignature, so the
+# gateway JWT gate is redundant. Disabling verify_jwt decouples webhook delivery
+# from Supabase API keys, so rotating keys can't 401 incoming webhooks.
+[functions.user-actions]
+verify_jwt = false
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/user-actions/index.ts
+++ b/supabase/functions/user-actions/index.ts
@@ -70,8 +70,23 @@ Deno.serve(async (req: Request) => {
     console.info(`Successfully handled rule: ${requestBody.rule.id}, ${requestBody.rule.type}`)
   } catch (error) {
     console.error(`Error processing request: ${error.message}, stack: ${error.stack}`)
+    // This function is publicly reachable (verify_jwt is disabled because it
+    // authenticates via the Missive HMAC signature), so unsigned or malformed
+    // requests reach here. Reject them cleanly without running handleError,
+    // which expects a verified Missive payload and would otherwise throw on a
+    // missing `rule` or spam the `errors` table with unauthenticated traffic.
+    if (error instanceof UnauthorizedError) {
+      return AppResponse.unauthorized(error.message)
+    }
+    if (error instanceof BadRequestError) {
+      return AppResponse.badRequest(error.message)
+    }
     if (requestBody) {
-      await handleError(requestBody, error)
+      try {
+        await handleError(requestBody, error)
+      } catch {
+        console.error('Failed to record error while handling request')
+      }
     }
     if (
       typeof error.message === 'string' &&


### PR DESCRIPTION
## Problem

After migrating to Supabase's new API key system + rotating keys, the `user-actions` Missive webhook started failing — every incoming webhook returned **401 at the Supabase gateway before the function ran**.

Root cause: `user-actions` was deployed with the default `verify_jwt = true`. To satisfy that gateway gate, Missive was sending a **legacy anon JWT** in the `Authorization` header. The new `sb_publishable_…`/`sb_secret_…` keys are **not JWTs** (Edge Functions only support JWT verification via the legacy anon/service_role keys), and the rotated legacy JWT became invalid — so the gateway rejected every webhook.

Confirmed against production:
- Logs showed a flood of `401`s on `user-actions` (gateway-level — the function code never returns 401).
- `invoke_history` shows successful processing as recently as `2026-06-02 03:17 UTC`, so `HMAC_SECRET` was never the issue — the breakage was purely the gateway JWT layer.

## Fix

1. **`config.toml`** — pin `[functions.user-actions] verify_jwt = false`. The function already authenticates webhooks via the Missive HMAC signature (`Missive.verifySignature`), so the gateway JWT gate is redundant. Disabling it decouples webhook delivery from Supabase API keys, so **future key rotations can't 401 this webhook again.**

2. **`index.ts` — harden the rejection path.** Because the function is now publicly reachable, unsigned/garbage requests reach the code. Return a clean `401`/`400` on signature/method failures *before* `handleError` (which expects a verified payload — it threw on a missing `rule`, producing `500`s, and logged unauthenticated traffic to the `errors` table). `handleError` is now wrapped so a logging failure can't surface as a `500`.

## Deployed & verified

Already deployed to prod (`user-actions` v234, `verify_jwt: false`, ACTIVE). Post-deploy probes:

| Request | Before | After |
|---|---|---|
| no-auth POST | `401` (gateway) | `401` (clean, function-level) |
| unsigned well-formed body | `500` | `401` |
| bad signature | `500` | `401` |
| GET (method not allowed) | `200` | `400` |
| valid Missive webhook | `401` (gateway) | reaches HMAC check → processes |

Auth failures no longer write to the `errors` table (verified: `0` rows from probe traffic).

> Note: committed unsigned (SSH signing key wasn't available in the deploy environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in webhook processing to distinguish between authentication errors and other failures, preventing error logs from disrupting request handling.

* **Chores**
  * Updated webhook authentication configuration to use alternative signature verification instead of standard API key validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->