### PR TITLE
[codex] Exclude CSV upload label from broadcasts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules
 .idea
 .vscode
 cov_profile
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -236,7 +236,6 @@ For details on how personalized campaigns work, see [Personalized Campaigns Docu
 - Broadcast queueing also excludes authors connected to a non-archived `CSV UPLOAD` label, including nested labels like
   `Campaigns/CSV UPLOAD`, because existing authors added through CSV campaigns may not have `added_via_file_upload`
   set.
--
 
 ## Related Repositories
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ For details on how personalized campaigns work, see [Personalized Campaigns Docu
   segment queries because these authors were recipients added through campaign file uploads and were not intended to be
   part of broadcasts. Including them in broadcasts could lead to unintended message delivery and potential compliance
   issues.
+- Broadcast queueing also excludes authors connected to a non-archived `CSV UPLOAD` label, including nested labels like
+  `Campaigns/CSV UPLOAD`, because existing authors added through CSV campaigns may not have `added_via_file_upload`
+  set.
 -
 
 ## Related Repositories

--- a/docs/blocker-register.md
+++ b/docs/blocker-register.md
@@ -1,0 +1,7 @@
+# Blocker Register
+
+## 2026-06-16
+
+- Local Supabase integration validation is blocked because the Docker daemon is unavailable at
+  `unix:///Users/j/.docker/run/docker.sock`. The focused `make-tests.ts` suite cannot reach local Postgres at
+  `127.0.0.1:54322` until the Supabase stack can start.

--- a/docs/current-cycle-worklog.md
+++ b/docs/current-cycle-worklog.md
@@ -10,3 +10,4 @@
 - Ran `deno lint` successfully.
 - Attempted `TZ=UTC deno test --no-check --no-lock --allow-all --env=.env.testing make-tests.ts`; blocked because
   Docker is not running and local Supabase Postgres is unavailable.
+- Started PR and production deployment follow-up for the CSV upload broadcast exclusion.

--- a/docs/current-cycle-worklog.md
+++ b/docs/current-cycle-worklog.md
@@ -18,3 +18,9 @@
   in production.
 - Ran Supabase security and performance advisors after DDL. Results were existing project-wide warnings; the new
   broadcast functions were not reported as mutable-search-path findings.
+- Addressed PR migration hardening feedback by removing the per-row helper, building a temporary exclusion set inside
+  `queue_broadcast_messages`, setting `search_path = public, pg_temp`, and ordering queued-message batches by
+  `phone_number`.
+- Applied production Supabase migration `20260616162907 harden_csv_upload_broadcast_exclusion`.
+- Verified the old helper was dropped in production and `queue_broadcast_messages` has
+  `search_path=public, pg_temp`.

--- a/docs/current-cycle-worklog.md
+++ b/docs/current-cycle-worklog.md
@@ -1,0 +1,12 @@
+# Current Cycle Worklog
+
+## 2026-06-16
+
+- Added migration `20260616090000_exclude_csv_upload_from_broadcasts.sql` to exclude authors from broadcast queueing
+  when they have `added_via_file_upload = true` or are connected to a non-archived `CSV UPLOAD` label.
+- Added focused regression coverage in `make-tests.ts` for an existing author connected to a `CSV UPLOAD` label.
+- Added the migration to the test setup migration list.
+- Updated `README.md` developer notes to document the CSV label exclusion.
+- Ran `deno lint` successfully.
+- Attempted `TZ=UTC deno test --no-check --no-lock --allow-all --env=.env.testing make-tests.ts`; blocked because
+  Docker is not running and local Supabase Postgres is unavailable.

--- a/docs/current-cycle-worklog.md
+++ b/docs/current-cycle-worklog.md
@@ -11,3 +11,10 @@
 - Attempted `TZ=UTC deno test --no-check --no-lock --allow-all --env=.env.testing make-tests.ts`; blocked because
   Docker is not running and local Supabase Postgres is unavailable.
 - Started PR and production deployment follow-up for the CSV upload broadcast exclusion.
+- Opened draft PR: https://github.com/PublicDataWorks/txt-outlier-backend/pull/102.
+- Applied production Supabase migration `20260616162541 exclude_csv_upload_from_broadcasts` to project
+  `TXT Outlier` (`pshrrdazlftosdtoevpf`).
+- Verified `public.is_broadcast_excluded_recipient('__codex_nonexistent_phone__')` returns `false` and the helper exists
+  in production.
+- Ran Supabase security and performance advisors after DDL. Results were existing project-wide warnings; the new
+  broadcast functions were not reported as mutable-search-path findings.

--- a/docs/execution-board.md
+++ b/docs/execution-board.md
@@ -1,0 +1,7 @@
+# Execution Board
+
+## Current Cycle
+
+- [x] 2026-06-16: Exclude CSV UPLOAD recipients from broadcast segments.
+  - State: Implemented with migration and regression coverage.
+  - Validation: `deno lint` passed; focused Supabase test blocked by local Docker daemon being unavailable.

--- a/docs/execution-board.md
+++ b/docs/execution-board.md
@@ -6,5 +6,5 @@
   - State: Implemented with migration and regression coverage.
   - Validation: `deno lint` passed; focused Supabase test blocked by local Docker daemon being unavailable.
 - [x] 2026-06-16: Publish PR and deploy CSV upload broadcast exclusion to production.
-  - State: PR opened and production migration applied.
-  - Validation: Production migration recorded and helper smoke check passed.
+  - State: PR opened and production migrations applied.
+  - Validation: Production hardening migration recorded; helper dropped; `queue_broadcast_messages` search path verified.

--- a/docs/execution-board.md
+++ b/docs/execution-board.md
@@ -5,3 +5,6 @@
 - [x] 2026-06-16: Exclude CSV UPLOAD recipients from broadcast segments.
   - State: Implemented with migration and regression coverage.
   - Validation: `deno lint` passed; focused Supabase test blocked by local Docker daemon being unavailable.
+- [ ] 2026-06-16: Publish PR and deploy CSV upload broadcast exclusion to production.
+  - State: In progress.
+  - Validation: Pending production migration application.

--- a/docs/execution-board.md
+++ b/docs/execution-board.md
@@ -5,6 +5,6 @@
 - [x] 2026-06-16: Exclude CSV UPLOAD recipients from broadcast segments.
   - State: Implemented with migration and regression coverage.
   - Validation: `deno lint` passed; focused Supabase test blocked by local Docker daemon being unavailable.
-- [ ] 2026-06-16: Publish PR and deploy CSV upload broadcast exclusion to production.
-  - State: In progress.
-  - Validation: Pending production migration application.
+- [x] 2026-06-16: Publish PR and deploy CSV upload broadcast exclusion to production.
+  - State: PR opened and production migration applied.
+  - Validation: Production migration recorded and helper smoke check passed.

--- a/docs/reference-index.md
+++ b/docs/reference-index.md
@@ -1,0 +1,7 @@
+# Reference Index
+
+- `README.md`: Broadcast/campaign system overview, broadcast queue flow, and developer notes.
+- `docs/campaigns.md`: Campaign behavior, CSV campaign labels, and file-based campaign flow.
+- `docs/testing.md`: Test setup expectations, including adding new migrations to `supabase/functions/tests/setup.ts`.
+- `supabase/migrations/0001_true_naoko.sql`: Prior `queue_broadcast_messages` definition.
+- `supabase/functions/tests/make-tests.ts`: Broadcast queueing integration tests.

--- a/docs/run-receipt.md
+++ b/docs/run-receipt.md
@@ -22,3 +22,9 @@ Required workflow artifacts:
 
 Follow-up:
 - PR creation and production deployment requested on 2026-06-16.
+- Opened draft PR https://github.com/PublicDataWorks/txt-outlier-backend/pull/102.
+- Deployed to production Supabase project `TXT Outlier` (`pshrrdazlftosdtoevpf`) as migration
+  `20260616162541 exclude_csv_upload_from_broadcasts`.
+- Production smoke check confirmed the exclusion helper exists and returns `false` for a nonexistent phone number.
+- Supabase advisors still report existing project-wide warnings, including RLS-enabled tables with no policies,
+  mutable search paths on unrelated functions, extension-in-public warnings, and available Postgres security patches.

--- a/docs/run-receipt.md
+++ b/docs/run-receipt.md
@@ -28,3 +28,8 @@ Follow-up:
 - Production smoke check confirmed the exclusion helper exists and returns `false` for a nonexistent phone number.
 - Supabase advisors still report existing project-wide warnings, including RLS-enabled tables with no policies,
   mutable search paths on unrelated functions, extension-in-public warnings, and available Postgres security patches.
+- PR review hardening follow-up deployed to production as migration
+  `20260616162907 harden_csv_upload_broadcast_exclusion`.
+- The final production version drops `public.is_broadcast_excluded_recipient(text)`, precomputes excluded broadcast
+  recipients in a temporary table inside `queue_broadcast_messages`, uses `search_path=public, pg_temp`, and orders
+  batch pagination by `phone_number`.

--- a/docs/run-receipt.md
+++ b/docs/run-receipt.md
@@ -1,0 +1,21 @@
+# Run Receipt
+
+## 2026-06-16
+
+Task: Exclude recipients with the `CSV UPLOAD` label from normal broadcast segments.
+
+Outcome:
+- Implemented a database-level broadcast recipient exclusion helper.
+- Replaced `queue_broadcast_messages` so regular and Inactive segment fill paths skip CSV-upload recipients.
+- Added regression coverage for a labeled existing author.
+- Recorded the validation blocker in `docs/blocker-register.md`.
+
+Validation:
+- Passed: `deno lint`.
+- Blocked: focused `make-tests.ts` integration run because Docker is not running and local Supabase Postgres is not
+  accepting connections on `127.0.0.1:54322`.
+
+Required workflow artifacts:
+- `WORKFLOW.md` was not present in this checkout before implementation.
+- Execution board, blocker register, current-cycle worklog, reference index, and this run receipt were created under
+  `docs/` because no existing copies were found.

--- a/docs/run-receipt.md
+++ b/docs/run-receipt.md
@@ -19,3 +19,6 @@ Required workflow artifacts:
 - `WORKFLOW.md` was not present in this checkout before implementation.
 - Execution board, blocker register, current-cycle worklog, reference index, and this run receipt were created under
   `docs/` because no existing copies were found.
+
+Follow-up:
+- PR creation and production deployment requested on 2026-06-16.

--- a/supabase/functions/tests/make-tests.ts
+++ b/supabase/functions/tests/make-tests.ts
@@ -2,12 +2,16 @@ import { describe, it } from 'jsr:@std/testing/bdd'
 import { assert, assertEquals, assertInstanceOf } from 'jsr:@std/assert'
 import { client } from './utils.ts'
 import './setup.ts'
-import { createAuthors } from './factories/author.ts'
+import { createAuthor, createAuthors } from './factories/author.ts'
 import { createBroadcast } from './factories/broadcast.ts'
 import { createSegment } from './factories/segment.ts'
 import supabase from '../_shared/lib/supabase.ts'
 import { and, eq, gt, sql } from 'drizzle-orm'
 import { broadcasts } from '../_shared/drizzle/schema.ts'
+import { createLabel } from './factories/label.ts'
+import { createConversation } from './factories/conversation.ts'
+import { createConversationAuthor } from './factories/conversation-author.ts'
+import { createConversationLabel } from './factories/conversation-label.ts'
 
 const FUNCTION_NAME = 'make/'
 
@@ -124,6 +128,53 @@ describe('MAKE BROADCAST', { sanitizeOps: false, sanitizeResources: false }, () 
       sql.raw('SELECT COUNT(*) as count FROM pgmq.q_broadcast_first_messages'),
     )
     assertEquals(totalQueuedMessages[0].count, '2', 'Should have messages for all authors')
+  })
+
+  it('should exclude authors with the CSV UPLOAD label from broadcast segments', async () => {
+    const eligibleAuthor = await createAuthor('+15550000001')
+    const csvUploadAuthor = await createAuthor('+15550000002')
+    const csvUploadLabel = await createLabel({
+      name: 'CSV UPLOAD',
+      nameWithParentNames: 'Campaigns/CSV UPLOAD',
+    })
+    const csvUploadConversation = await createConversation()
+    await createConversationAuthor({
+      conversationId: csvUploadConversation.id,
+      authorPhoneNumber: csvUploadAuthor.phoneNumber,
+    })
+    await createConversationLabel({
+      conversationId: csvUploadConversation.id,
+      labelId: csvUploadLabel.id,
+    })
+
+    await createSegment({
+      name: 'Inactive',
+      query: 'SELECT a.phone_number FROM public.authors a ORDER BY a.phone_number',
+    })
+
+    const broadcast = await createBroadcast({
+      editable: true,
+      firstMessage: 'Test first message',
+      secondMessage: 'Test second message',
+      noUsers: 2,
+      delay: 600,
+    })
+    await createSegment({
+      broadcastId: broadcast.id!,
+      query: 'SELECT a.phone_number FROM public.authors a ORDER BY a.phone_number',
+    })
+
+    await client.functions.invoke(FUNCTION_NAME, {
+      method: 'POST',
+      body: { run_at_utc: new Date().toISOString().slice(0, 16).replace('T', ' ') },
+    })
+
+    const queuedMessages = await supabase.execute(
+      sql.raw('SELECT message FROM pgmq.q_broadcast_first_messages'),
+    )
+
+    assertEquals(queuedMessages.length, 1)
+    assertEquals(queuedMessages[0].message.recipient_phone_number, eligibleAuthor.phoneNumber)
   })
 
   it('should create new broadcast when another broadcast is running', async () => {

--- a/supabase/functions/tests/setup.ts
+++ b/supabase/functions/tests/setup.ts
@@ -23,6 +23,7 @@ beforeEach(async () => {
     '../../migrations/20250506034003_add_campaign_personalized_recipients.sql',
     '../../migrations/20250507070855_add_label_id_to_campaigns.sql',
     '../../migrations/20250508095220_add_original_messages_to_broadcasts.sql',
+    '../../migrations/20260616090000_exclude_csv_upload_from_broadcasts.sql',
   ]
 
   for (const filePath of migrationFiles) {

--- a/supabase/functions/tests/setup.ts
+++ b/supabase/functions/tests/setup.ts
@@ -24,6 +24,7 @@ beforeEach(async () => {
     '../../migrations/20250507070855_add_label_id_to_campaigns.sql',
     '../../migrations/20250508095220_add_original_messages_to_broadcasts.sql',
     '../../migrations/20260616090000_exclude_csv_upload_from_broadcasts.sql',
+    '../../migrations/20260616170000_harden_csv_upload_broadcast_exclusion.sql',
   ]
 
   for (const filePath of migrationFiles) {

--- a/supabase/migrations/20260616090000_exclude_csv_upload_from_broadcasts.sql
+++ b/supabase/migrations/20260616090000_exclude_csv_upload_from_broadcasts.sql
@@ -1,0 +1,130 @@
+CREATE OR REPLACE FUNCTION public.is_broadcast_excluded_recipient(
+    p_phone_number text
+) RETURNS boolean
+SET search_path = ''
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM public.authors a
+        WHERE a.phone_number = p_phone_number
+        AND COALESCE(a.added_via_file_upload, FALSE) = TRUE
+    )
+    OR EXISTS (
+        SELECT 1
+        FROM public.conversations_authors ca
+        JOIN public.conversations_labels cl
+            ON cl.conversation_id = ca.conversation_id
+        JOIN public.labels l
+            ON l.id = cl.label_id
+        WHERE ca.author_phone_number = p_phone_number
+        AND cl.is_archived = FALSE
+        AND (
+            UPPER(BTRIM(l.name)) = 'CSV UPLOAD'
+            OR UPPER(BTRIM(l.name_with_parent_names)) = 'CSV UPLOAD'
+            OR UPPER(BTRIM(l.name_with_parent_names)) LIKE '%/CSV UPLOAD'
+        )
+    );
+$$ LANGUAGE sql STABLE;
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION public.queue_broadcast_messages(
+    p_broadcast_id int
+) RETURNS void
+SET search_path = ''
+AS $$
+DECLARE
+    v_first_message text;
+    v_second_message text;
+    v_segment_record RECORD;
+    v_delay int;
+    v_offset int;
+    v_target_users int;
+    v_batch_size constant int := 100;
+    v_current_count int;
+    v_inactive_segment_id int;
+BEGIN
+    -- Get broadcast info
+    SELECT
+        first_message,
+        second_message,
+        no_users,
+        delay INTO
+        v_first_message,
+        v_second_message,
+        v_target_users,
+        v_delay
+    FROM public.broadcasts
+    WHERE id = p_broadcast_id;
+
+    DROP TABLE IF EXISTS recipients_temp; -- Could be ON COMMIT DROP
+    CREATE TEMPORARY TABLE recipients_temp (
+        phone_number text PRIMARY KEY,
+        segment_id int
+    );
+
+    -- Process regular segments with their ratios
+    FOR v_segment_record IN (
+        SELECT
+            bs.segment_id,
+            s.query,
+            FLOOR(bs.ratio * v_target_users / 100) as segment_limit
+        FROM public.broadcasts_segments bs
+        JOIN public.audience_segments s ON s.id = bs.segment_id
+        WHERE bs.broadcast_id = p_broadcast_id
+        AND s.name != 'Inactive'
+    ) LOOP
+        EXECUTE format(
+            'INSERT INTO recipients_temp (phone_number, segment_id)
+            SELECT DISTINCT sq.phone_number, %s as segment_id
+            FROM (%s LIMIT %s) AS sq
+            WHERE sq.phone_number NOT IN (SELECT phone_number FROM recipients_temp)
+            AND NOT public.is_broadcast_excluded_recipient(sq.phone_number)
+            ON CONFLICT (phone_number) DO NOTHING',
+            v_segment_record.segment_id,
+            v_segment_record.query,
+            v_segment_record.segment_limit
+        );
+    END LOOP;
+
+    SELECT COUNT(*) INTO v_current_count FROM recipients_temp;
+
+    IF v_current_count < v_target_users THEN
+        SELECT id INTO v_inactive_segment_id FROM public.audience_segments WHERE name = 'Inactive';
+
+        EXECUTE format(
+            'INSERT INTO recipients_temp (phone_number, segment_id)
+            SELECT DISTINCT sq.phone_number, %s
+            FROM (
+                SELECT DISTINCT inner_sq.phone_number
+                FROM (%s) AS inner_sq
+                WHERE inner_sq.phone_number NOT IN (SELECT phone_number FROM recipients_temp)
+                AND NOT public.is_broadcast_excluded_recipient(inner_sq.phone_number)
+                LIMIT %s
+            ) AS sq
+            ON CONFLICT (phone_number) DO NOTHING',
+            v_inactive_segment_id,
+            (SELECT query FROM public.audience_segments WHERE name = 'Inactive'),
+            v_target_users - v_current_count
+        );
+    END IF;
+
+    -- Queue in batches
+    FOR v_offset IN 0..CEIL((SELECT COUNT(*) FROM recipients_temp)::float / v_batch_size) - 1 LOOP
+        PERFORM pgmq.send_batch(
+            'broadcast_first_messages',
+            ARRAY(
+                SELECT jsonb_build_object(
+                    'recipient_phone_number', phone_number,
+                    'broadcast_id', p_broadcast_id,
+                    'segment_id', segment_id,
+                    'first_message', v_first_message,
+                    'second_message', v_second_message,
+                    'delay', v_delay  -- in seconds
+                )
+                FROM recipients_temp
+                LIMIT v_batch_size
+                OFFSET v_offset * v_batch_size
+            )
+        );
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;

--- a/supabase/migrations/20260616170000_harden_csv_upload_broadcast_exclusion.sql
+++ b/supabase/migrations/20260616170000_harden_csv_upload_broadcast_exclusion.sql
@@ -1,3 +1,5 @@
+DROP FUNCTION IF EXISTS public.is_broadcast_excluded_recipient(text);
+--> statement-breakpoint
 CREATE OR REPLACE FUNCTION public.queue_broadcast_messages(
     p_broadcast_id int
 ) RETURNS void


### PR DESCRIPTION
## Summary
- exclude CSV upload recipients directly inside `queue_broadcast_messages`
- skip authors with `added_via_file_upload = true` and authors connected to a non-archived `CSV UPLOAD` label in both regular and Inactive segment fills
- precompute the exclusion set in a temp table, use `search_path=public, pg_temp`, and order queued-message batching by `phone_number`
- add regression coverage for an existing author connected to a `CSV UPLOAD` label
- add repo-local run tracking artifacts because the required workflow files were absent

## Root cause
Existing authors added to CSV campaigns can receive the `CSV UPLOAD` label without being marked `added_via_file_upload`. The broadcast queue builder trusted segment SQL directly, so those labeled authors could still be selected for normal broadcasts.

## Review follow-up
- addressed Gemini migration hardening feedback in `51b47f8`
- removed the per-row SQL helper from the final path
- added a production follow-up migration that drops the helper and keeps all exclusion logic inside `queue_broadcast_messages`
- changed function search path to `public, pg_temp` so temp tables and dynamic queries work without mutable-search-path findings
- added deterministic `ORDER BY phone_number` before batching recipients

## Validation
- `deno lint`
- production schema preflight confirmed required tables, columns, and functions exist
- production migration verification confirmed `public.is_broadcast_excluded_recipient(text)` is gone and `queue_broadcast_messages` has `search_path=public, pg_temp`
- Supabase security advisor still reports existing project-wide warnings; no `queue_broadcast_messages` mutable-search-path finding remains
- attempted focused `make-tests.ts` run; blocked because Docker is not running and local Supabase Postgres at `127.0.0.1:54322` is unavailable

## Deployment
- deployed to production Supabase project `TXT Outlier` (`pshrrdazlftosdtoevpf`)
- production migration recorded as `20260616162541 exclude_csv_upload_from_broadcasts`
- production hardening migration recorded as `20260616162907 harden_csv_upload_broadcast_exclusion`
- no Edge Function deploy was needed; this change is database functions only