### PR TITLE
chore: declare verify_jwt = false for admin-action and user-actions

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -275,6 +275,12 @@ verify_jwt = false
 [functions.archive-double-failures]
 verify_jwt = false
 
+[functions.admin-action]
+verify_jwt = false
+
+[functions.user-actions]
+verify_jwt = false
+
 [analytics]
 enabled = false
 port = 54327


### PR DESCRIPTION
Records in the repo what was only ever set in the dashboard. Both functions are Missive webhooks that gate on `Missive.verifySignature` before doing any work, so the platform JWT check adds nothing — and Missive doesn't send a Supabase JWT.

Not a new hole: this matches the functions' current deployed behavior. Without the entry, a redeploy could flip the platform check back on and start rejecting webhooks at the gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added support for two Edge Functions with JWT verification disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->